### PR TITLE
Implement traffic metrics

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,8 @@ tor-dirmgr = "0.31.0"
 tor-netdir = "0.31.0"
 tor-proto = "0.31.0"
 tor-linkspec = "0.31.0"
+pin-project = "1.1"
+async-trait = "0.1"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
 use crate::state::AppState;
+use crate::traffic::TrafficCounters;
 use serde::Serialize;
 use tauri::{Manager, State};
 
@@ -66,6 +67,11 @@ pub async fn get_status(state: State<'_, AppState>) -> Result<String> {
 #[tauri::command]
 pub async fn get_active_circuit(state: State<'_, AppState>) -> Result<Vec<RelayInfo>> {
     state.tor_manager.get_active_circuit().await
+}
+
+#[tauri::command]
+pub async fn get_traffic_metrics(state: State<'_, AppState>) -> Result<TrafficCounters> {
+    Ok(state.tor_manager.get_traffic().await)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ pub fn run() {
             commands::disconnect,
             commands::get_status,
             commands::get_active_circuit,
+            commands::get_traffic_metrics,
             commands::get_logs,
             commands::clear_logs
         ])

--- a/src-tauri/src/traffic.rs
+++ b/src-tauri/src/traffic.rs
@@ -1,0 +1,132 @@
+use async_trait::async_trait;
+use futures::io::{AsyncRead, AsyncWrite};
+use futures::Stream;
+use pin_project::pin_project;
+use std::io::Result as IoResult;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use tor_rtcompat::{NetStreamListener, NetStreamProvider, StreamOps};
+
+#[derive(Debug, Clone, Default)]
+pub struct TrafficCounters {
+    pub bytes_sent: usize,
+    pub bytes_received: usize,
+}
+
+#[pin_project]
+#[derive(Clone)]
+pub struct Counting<R> {
+    #[pin]
+    inner: R,
+    counters: Arc<Mutex<TrafficCounters>>,
+}
+
+impl<R> Counting<R> {
+    pub fn new(inner: R) -> Self
+    where
+        R: NetStreamProvider,
+    {
+        Self {
+            inner,
+            counters: Arc::new(Mutex::new(TrafficCounters::default())),
+        }
+    }
+
+    pub fn counters(&self) -> TrafficCounters {
+        self.counters.lock().expect("lock poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl<R> NetStreamProvider for Counting<R>
+where
+    R: NetStreamProvider + Send + Sync,
+{
+    type Stream = Counting<R::Stream>;
+    type Listener = Counting<R::Listener>;
+
+    async fn connect(&self, addr: &SocketAddr) -> IoResult<Self::Stream> {
+        let inner = self.inner.connect(addr).await?;
+        Ok(Counting {
+            inner,
+            counters: self.counters.clone(),
+        })
+    }
+
+    async fn listen(&self, addr: &SocketAddr) -> IoResult<Self::Listener> {
+        let inner = self.inner.listen(addr).await?;
+        Ok(Counting {
+            inner,
+            counters: self.counters.clone(),
+        })
+    }
+}
+
+impl<S: AsyncRead> AsyncRead for Counting<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<IoResult<usize>> {
+        let this = self.project();
+        let outcome = this.inner.poll_read(cx, buf);
+        if let Poll::Ready(Ok(n)) = outcome {
+            this.counters.lock().expect("poisoned").bytes_received += n;
+        }
+        outcome
+    }
+}
+
+impl<S: AsyncWrite> AsyncWrite for Counting<S> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<IoResult<usize>> {
+        let this = self.project();
+        let outcome = this.inner.poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = outcome {
+            this.counters.lock().expect("poisoned").bytes_sent += n;
+        }
+        outcome
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<IoResult<()>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<IoResult<()>> {
+        self.project().inner.poll_close(cx)
+    }
+}
+
+impl<S: StreamOps> StreamOps for Counting<S> {
+    fn set_tcp_notsent_lowat(&self, notsent_lowat: u32) -> IoResult<()> {
+        self.inner.set_tcp_notsent_lowat(notsent_lowat)
+    }
+
+    fn new_handle(&self) -> Box<dyn StreamOps + Send + Unpin> {
+        self.inner.new_handle()
+    }
+}
+
+impl<S, T> Stream for Counting<S>
+where
+    S: Stream<Item = IoResult<(T, SocketAddr)>>,
+{
+    type Item = IoResult<(Counting<T>, SocketAddr)>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        match this.inner.poll_next(cx) {
+            Poll::Ready(Some(Ok((inner, addr)))) => Poll::Ready(Some(Ok((
+                Counting {
+                    inner,
+                    counters: this.counters.clone(),
+                },
+                addr,
+            )))),
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,49 +11,77 @@
 
 	import { onMount } from 'svelte';
 
-	let activeCircuit: any[] = [];
-	let circuitInterval: any = null;
+        let activeCircuit: any[] = [];
+        let circuitInterval: any = null;
+        let totalTrafficMB = 0;
+        let trafficInterval: any = null;
 
-	async function fetchCircuit() {
-		if ($torStore.status === 'CONNECTED') {
-			try {
-				activeCircuit = await invoke('get_active_circuit');
-			} catch (e) {
-				console.error("Failed to get active circuit:", e);
-				activeCircuit = [];
-			}
-		} else {
-			activeCircuit = [];
-		}
-	}
+        async function fetchCircuit() {
+                if ($torStore.status === 'CONNECTED') {
+                        try {
+                                activeCircuit = await invoke('get_active_circuit');
+                        } catch (e) {
+                                console.error("Failed to get active circuit:", e);
+                                activeCircuit = [];
+                        }
+                } else {
+                        activeCircuit = [];
+                }
+        }
+
+        async function fetchTraffic() {
+                if ($torStore.status === 'CONNECTED') {
+                        try {
+                                const metrics = await invoke('get_traffic_metrics');
+                                totalTrafficMB = Math.floor((metrics.bytes_sent + metrics.bytes_received) / (1024 * 1024));
+                        } catch (e) {
+                                console.error('Failed to get traffic metrics:', e);
+                                totalTrafficMB = 0;
+                        }
+                } else {
+                        totalTrafficMB = 0;
+                }
+        }
 
 	// Fetch circuit info periodically when connected
-	$: if ($torStore.status === 'CONNECTED' && !circuitInterval) {
-		fetchCircuit(); // initial fetch
-		circuitInterval = setInterval(fetchCircuit, 5000); // refresh every 5 seconds
-	} else if ($torStore.status !== 'CONNECTED' && circuitInterval) {
-		clearInterval(circuitInterval);
-		circuitInterval = null;
-		activeCircuit = [];
-	}
+        $: if ($torStore.status === 'CONNECTED' && !circuitInterval) {
+                fetchCircuit(); // initial fetch
+                circuitInterval = setInterval(fetchCircuit, 5000); // refresh every 5 seconds
+        } else if ($torStore.status !== 'CONNECTED' && circuitInterval) {
+                clearInterval(circuitInterval);
+                circuitInterval = null;
+                activeCircuit = [];
+        }
 
-	onMount(() => {
-		return () => {
-			// Ensure interval is cleared on component unmount
-			if (circuitInterval) {
-				clearInterval(circuitInterval);
-			}
-		};
-	});
+        $: if ($torStore.status === 'CONNECTED' && !trafficInterval) {
+                fetchTraffic();
+                trafficInterval = setInterval(fetchTraffic, 5000);
+        } else if ($torStore.status !== 'CONNECTED' && trafficInterval) {
+                clearInterval(trafficInterval);
+                trafficInterval = null;
+                totalTrafficMB = 0;
+        }
+
+        onMount(() => {
+                return () => {
+                        // Ensure interval is cleared on component unmount
+                        if (circuitInterval) {
+                                clearInterval(circuitInterval);
+                        }
+                        if (trafficInterval) {
+                                clearInterval(trafficInterval);
+                        }
+                };
+        });
 </script>
 
 <div class="p-6 max-w-6xl mx-auto">
 	<div class="bg-white/20 backdrop-blur-xl rounded-[32px] border border-white/20 p-6 flex flex-col gap-2">
-		<StatusCard
-			status={$torStore.status}
-			totalTrafficMB={0}
-			pingMs={undefined}
-		/>
+                <StatusCard
+                        status={$torStore.status}
+                        totalTrafficMB={totalTrafficMB}
+                        pingMs={undefined}
+                />
 
 		<TorChain
 			isConnected={$torStore.status === 'CONNECTED'}


### PR DESCRIPTION
## Summary
- track traffic stats with a Counting TCP wrapper
- expose `get_traffic_metrics` command
- wire up new runtime in TorManager
- show traffic totals in StatusCard

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a23e641883339ca2ac5789840dbd