### PR TITLE
Implement Tor backoff and circuit isolation

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -22,7 +22,7 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
         }
 
         // Perform the actual connection
-        match tor_manager.connect().await {
+        match tor_manager.connect_with_backoff(5).await {
             Ok(_) => {
                 if let Err(e) = app_handle.emit_all("tor-status-update", serde_json::json!({ "status": "CONNECTED", "bootstrapProgress": 100 })) {
                     log::error!("Failed to emit status update: {}", e);
@@ -66,6 +66,16 @@ pub async fn get_status(state: State<'_, AppState>) -> Result<String> {
 #[tauri::command]
 pub async fn get_active_circuit(state: State<'_, AppState>) -> Result<Vec<RelayInfo>> {
     state.tor_manager.get_active_circuit().await
+}
+
+#[tauri::command]
+pub async fn get_isolated_circuit(state: State<'_, AppState>, domain: String) -> Result<Vec<RelayInfo>> {
+    state.tor_manager.get_isolated_circuit(domain).await
+}
+
+#[tauri::command]
+pub async fn set_exit_country(state: State<'_, AppState>, country: Option<String>) -> Result<()> {
+    state.tor_manager.set_exit_country(country).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,8 @@ pub fn run() {
             commands::disconnect,
             commands::get_status,
             commands::get_active_circuit,
+            commands::get_isolated_circuit,
+            commands::set_exit_country,
             commands::get_logs,
             commands::clear_logs
         ])

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -1,25 +1,31 @@
 use crate::commands::RelayInfo;
 use crate::error::{Error, Result};
-use arti_client::{TorClient, TorClientConfig};
+use arti_client::{client::StreamPrefs, TorClient, TorClientConfig};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tor_circmgr::isolation::StreamIsolation;
+use tor_circmgr::isolation::{IsolationToken, StreamIsolation};
+use tor_geoip::CountryCode;
 use tor_dirmgr::Timeliness;
 use tor_linkspec::{HasAddrs, HasRelayIds};
 use tor_rtcompat::PreferredRuntime;
 
 pub struct TorManager {
     client: Arc<Mutex<Option<TorClient<PreferredRuntime>>>>,
+    isolation_tokens: Arc<Mutex<HashMap<String, IsolationToken>>>,
+    exit_country: Arc<Mutex<Option<CountryCode>>>,
 }
 
 impl TorManager {
     pub fn new() -> Self {
         Self {
             client: Arc::new(Mutex::new(None)),
+            isolation_tokens: Arc::new(Mutex::new(HashMap::new())),
+            exit_country: Arc::new(Mutex::new(None)),
         }
     }
 
-    pub async fn connect(&self) -> Result<()> {
+    async fn connect_once(&self) -> Result<()> {
         if self.is_connected().await {
             return Err(Error::AlreadyConnected);
         }
@@ -31,12 +37,45 @@ impl TorManager {
         Ok(())
     }
 
+    pub async fn connect(&self) -> Result<()> {
+        self.connect_once().await
+    }
+
+    pub async fn connect_with_backoff(&self, max_retries: u32) -> Result<()> {
+        let mut attempt = 0;
+        let mut delay = std::time::Duration::from_secs(1);
+        loop {
+            match self.connect_once().await {
+                Ok(_) => return Ok(()),
+                Err(e) => {
+                    attempt += 1;
+                    if attempt > max_retries {
+                        return Err(e);
+                    }
+                    tokio::time::sleep(delay).await;
+                    delay *= 2;
+                }
+            }
+        }
+    }
+
     pub async fn disconnect(&self) -> Result<()> {
         let mut client_guard = self.client.lock().await;
         if client_guard.take().is_none() {
             return Err(Error::NotConnected);
         }
         // Client is dropped here, which handles shutdown.
+        Ok(())
+    }
+
+    pub async fn set_exit_country(&self, country: Option<String>) -> Result<()> {
+        let mut guard = self.exit_country.lock().await;
+        if let Some(cc) = country {
+            let code = CountryCode::new(&cc).map_err(|e| Error::Tor(e.to_string()))?;
+            *guard = Some(code);
+        } else {
+            *guard = None;
+        }
         Ok(())
     }
 
@@ -94,6 +133,63 @@ impl TorManager {
                         ip_address: "?.?.?.?".to_string(),
                         country: "XX".to_string(),
                     }
+                }
+            })
+            .collect();
+
+        Ok(relays)
+    }
+
+    pub async fn get_isolated_circuit(&self, domain: String) -> Result<Vec<RelayInfo>> {
+        let client_guard = self.client.lock().await;
+        let client = client_guard.as_ref().ok_or(Error::NotConnected)?;
+
+        let mut tokens = self.isolation_tokens.lock().await;
+        let token = tokens.entry(domain).or_insert_with(IsolationToken::new);
+
+        let netdir = client
+            .dirmgr()
+            .netdir(Timeliness::Timely)
+            .map_err(|e| Error::NetDir(e.to_string()))?;
+
+        let isolation = StreamIsolation::builder()
+            .owner_token(*token)
+            .build()
+            .expect("StreamIsolation builder failed");
+
+        let prefs = {
+            let guard = self.exit_country.lock().await;
+            guard.map(|cc| {
+                let mut p = StreamPrefs::new();
+                p.exit_country(cc);
+                p
+            })
+        };
+
+        let circuit = client
+            .circmgr()
+            .get_or_launch_exit((&*netdir).into(), &[], isolation, prefs)
+            .await
+            .map_err(|e| Error::Circuit(e.to_string()))?;
+
+        let relays = circuit
+            .path_ref()
+            .map_err(|e| Error::Circuit(e.to_string()))?
+            .hops()
+            .iter()
+            .map(|hop| {
+                if let Some(relay) = hop.as_chan_target() {
+                    let nickname = relay
+                        .rsa_identity()
+                        .map(|id| format!("${}", id.to_string().chars().take(8).collect::<String>()))
+                        .unwrap_or_else(|| "$unknown".to_string());
+                    let ip_address = relay
+                        .addrs()
+                        .get(0)
+                        .map_or_else(|| "?.?.?.?".to_string(), |addr| addr.to_string());
+                    RelayInfo { nickname, ip_address, country: "XX".to_string() }
+                } else {
+                    RelayInfo { nickname: "<virtual>".to_string(), ip_address: "?.?.?.?".to_string(), country: "XX".to_string() }
                 }
             })
             .collect();


### PR DESCRIPTION
## Summary
- add exponential backoff support in `TorManager`
- track isolation tokens and exit country
- expose `get_isolated_circuit` and `set_exit_country` Tauri commands
- use backoff when connecting

## Testing
- `cargo check --lib` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861a5157e3483338c266d85d4397a08