### PR TITLE
Add traffic metrics via sysinfo

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 rustls = "0.23"
 rustls-pemfile = "2"
 anyhow = "1"
+sysinfo = { version = "0.30", default-features = false }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,6 +10,12 @@ pub struct RelayInfo {
     pub country: String,
 }
 
+#[derive(Serialize, Clone)]
+pub struct TrafficMetrics {
+    pub bytes_sent: u64,
+    pub bytes_received: u64,
+}
+
 #[tauri::command]
 pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -> Result<()> {
     let tor_manager = state.tor_manager.clone();
@@ -75,6 +81,12 @@ pub async fn new_identity(app_handle: tauri::AppHandle, state: State<'_, AppStat
     app_handle.emit_all("tor-status-update", serde_json::json!({ "status": "NEW_IDENTITY" }))?;
     Ok(())
 }
+
+#[tauri::command]
+pub async fn get_traffic_metrics(state: State<'_, AppState>) -> Result<TrafficMetrics> {
+    let (sent, received) = state.tor_manager.traffic_metrics();
+    Ok(TrafficMetrics { bytes_sent: sent, bytes_received: received })
+}
 #[tauri::command]
 pub async fn get_logs(state: State<'_, AppState>) -> Result<Vec<String>> {
     state.read_logs().await
@@ -84,3 +96,4 @@ pub async fn get_logs(state: State<'_, AppState>) -> Result<Vec<String>> {
 pub async fn clear_logs(state: State<'_, AppState>) -> Result<()> {
     state.clear_log_file().await
 }
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ pub fn run() {
             commands::disconnect,
             commands::get_status,
             commands::get_active_circuit,
+            commands::get_traffic_metrics,
             commands::get_logs,
             commands::clear_logs
         ])


### PR DESCRIPTION
## Summary
- track bytes sent/received in `TorManager`
- expose `get_traffic_metrics` command from backend
- display traffic amount in StatusCard

## Testing
- `cargo check` *(fails: `glib-2.0` pkg-config missing)*
- `npm run check` *(fails: `svelte-kit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a650a114833390e04136d9cb69aa