### PR TITLE
Add mockable TorManager and tests

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,10 @@ rustls = "0.23"
 rustls-pemfile = "2"
 anyhow = "1"
 
+[dev-dependencies]
+async-trait = "0.1"
+once_cell = "1"
+
 [features]
 # by default Tauri runs in production mode
 # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,13 +1,15 @@
 use crate::error::Result;
-use crate::tor_manager::TorManager;
+use crate::tor_manager::{TorClientBehavior, TorManager};
+use arti_client::TorClient;
+use tor_rtcompat::PreferredRuntime;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs::{self, OpenOptions};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 
-pub struct AppState {
-    pub tor_manager: Arc<TorManager>,
+pub struct AppState<C: TorClientBehavior = TorClient<PreferredRuntime>> {
+    pub tor_manager: Arc<TorManager<C>>,
     /// Path to the persistent log file
     pub log_file: PathBuf,
     /// Mutex used to serialize file writes
@@ -16,7 +18,7 @@ pub struct AppState {
     pub max_log_lines: usize,
 }
 
-impl Default for AppState {
+impl<C: TorClientBehavior> Default for AppState<C> {
     fn default() -> Self {
         let log_file = std::env::current_dir()
             .unwrap_or_else(|_| PathBuf::from("."))

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tauri::Manager;
+use once_cell::sync::Lazy;
+use std::collections::VecDeque;
+use std::sync::Mutex as StdMutex;
+
+use torwell84::commands;
+use torwell84::state::AppState;
+use torwell84::tor_manager::{TorManager, TorClientBehavior, TorClientConfig};
+use torwell84::error::Error;
+
+#[derive(Clone, Default)]
+struct MockTorClient {
+    reconfigure_ok: bool,
+    build_ok: bool,
+}
+
+static CONNECT_RESULTS: Lazy<StdMutex<VecDeque<Result<MockTorClient, String>>>> =
+    Lazy::new(|| StdMutex::new(VecDeque::new()));
+
+impl MockTorClient {
+    fn push_result(res: Result<MockTorClient, String>) {
+        CONNECT_RESULTS.lock().unwrap().push_back(res);
+    }
+}
+
+#[async_trait::async_trait]
+impl TorClientBehavior for MockTorClient {
+    async fn create_bootstrapped(_config: TorClientConfig) -> std::result::Result<Self, String> {
+        CONNECT_RESULTS.lock().unwrap().pop_front().expect("no result")
+    }
+    fn reconfigure(&self, _config: &TorClientConfig) -> std::result::Result<(), String> {
+        if self.reconfigure_ok { Ok(()) } else { Err("reconf".into()) }
+    }
+    fn retire_all_circs(&self) {}
+    async fn build_new_circuit(&self) -> std::result::Result<(), String> {
+        if self.build_ok { Ok(()) } else { Err("build".into()) }
+    }
+}
+
+fn mock_state() -> AppState<MockTorClient> {
+    AppState {
+        tor_manager: Arc::new(TorManager::new()),
+        log_file: PathBuf::from("test.log"),
+        log_lock: Arc::new(Mutex::new(())),
+        max_log_lines: 1000,
+    }
+}
+
+#[tokio::test]
+async fn command_get_status() {
+    let mut app = tauri::test::mock_app();
+    app.manage(mock_state());
+    let state = app.state::<AppState<MockTorClient>>();
+    let status = commands::get_status(state).await.unwrap();
+    assert_eq!(status, "DISCONNECTED");
+}

--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -1,0 +1,110 @@
+use once_cell::sync::Lazy;
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use torwell84::tor_manager::{TorManager, TorClientBehavior, TorClientConfig};
+use torwell84::error::Error;
+
+#[derive(Clone, Default)]
+struct MockTorClient {
+    reconfigure_ok: bool,
+    build_ok: bool,
+}
+
+static CONNECT_RESULTS: Lazy<Mutex<VecDeque<Result<MockTorClient, String>>>> =
+    Lazy::new(|| Mutex::new(VecDeque::new()));
+
+impl MockTorClient {
+    fn push_result(res: Result<MockTorClient, String>) {
+        CONNECT_RESULTS.lock().unwrap().push_back(res);
+    }
+}
+
+#[async_trait::async_trait]
+impl TorClientBehavior for MockTorClient {
+    async fn create_bootstrapped(_config: TorClientConfig) -> std::result::Result<Self, String> {
+        CONNECT_RESULTS
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("no result")
+    }
+
+    fn reconfigure(&self, _config: &TorClientConfig) -> std::result::Result<(), String> {
+        if self.reconfigure_ok {
+            Ok(())
+        } else {
+            Err("reconf".into())
+        }
+    }
+
+    fn retire_all_circs(&self) {}
+
+    async fn build_new_circuit(&self) -> std::result::Result<(), String> {
+        if self.build_ok {
+            Ok(())
+        } else {
+            Err("build".into())
+        }
+    }
+}
+
+#[tokio::test]
+async fn connect_with_backoff_success() {
+    MockTorClient::push_result(Err("fail".into()));
+    MockTorClient::push_result(Ok(MockTorClient::default()));
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    let res = manager.connect_with_backoff(5).await;
+    assert!(res.is_ok());
+}
+
+#[tokio::test]
+async fn connect_with_backoff_error() {
+    MockTorClient::push_result(Err("e1".into()));
+    MockTorClient::push_result(Err("e2".into()));
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    let res = manager.connect_with_backoff(1).await;
+    assert!(matches!(res, Err(Error::Bootstrap(_))));
+}
+
+#[tokio::test]
+async fn connect_when_already_connected() {
+    MockTorClient::push_result(Ok(MockTorClient::default()));
+    MockTorClient::push_result(Ok(MockTorClient::default()));
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    manager.connect().await.unwrap();
+    let res = manager.connect_with_backoff(0).await;
+    assert!(matches!(res, Err(Error::AlreadyConnected)));
+}
+
+#[tokio::test]
+async fn new_identity_success() {
+    MockTorClient::push_result(Ok(MockTorClient { reconfigure_ok: true, build_ok: true }));
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    manager.connect().await.unwrap();
+    assert!(manager.new_identity().await.is_ok());
+}
+
+#[tokio::test]
+async fn new_identity_not_connected() {
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    let res = manager.new_identity().await;
+    assert!(matches!(res, Err(Error::NotConnected)));
+}
+
+#[tokio::test]
+async fn new_identity_reconfigure_error() {
+    MockTorClient::push_result(Ok(MockTorClient { reconfigure_ok: false, build_ok: true }));
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    manager.connect().await.unwrap();
+    let res = manager.new_identity().await;
+    assert!(matches!(res, Err(Error::Identity(_))));
+}
+
+#[tokio::test]
+async fn new_identity_build_error() {
+    MockTorClient::push_result(Ok(MockTorClient { reconfigure_ok: true, build_ok: false }));
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    manager.connect().await.unwrap();
+    let res = manager.new_identity().await;
+    assert!(matches!(res, Err(Error::Circuit(_))));
+}


### PR DESCRIPTION
## Summary
- make `TorManager` generic over a new `TorClientBehavior` trait so client logic can be mocked
- update `AppState` to accept a generic tor client type
- add integration tests for tor manager logic using a mocked client
- add basic command test with `mock_app`
- enable async test helpers in dev-dependencies

## Testing
- `cargo test --verbose` *(fails: failed to run custom build command for `glib-sys v0.15.10`)*

------
https://chatgpt.com/codex/tasks/task_e_6861b5d2b43c83338aafbf9052ebefa3