### PR TITLE
Implement certificate rotation

### DIFF
--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -4,7 +4,8 @@ Torwell84 uses certificate pinning to defend against man-in-the-middle attacks. 
 
 ## Rotation Procedure
 1. The application fetches new certificates from a trusted endpoint using the existing pinned certificate.
-2. The new certificate replaces `src-tauri/certs/server.pem` on success.
-3. If the download fails, the previous certificate remains in place and continues to be used.
+2. Downloaded PEM files are saved to `src-tauri/certs/server.pem`.
+3. `SecureHttpClient` reloads the file automatically so the new certificate is used without restarting the app.
+4. If the download fails, the previous certificate remains in place and continues to be used.
 
 This process ensures that the client always validates TLS connections against a known certificate while still allowing updates when required.

--- a/src-tauri/src/secure_http.rs
+++ b/src-tauri/src/secure_http.rs
@@ -6,16 +6,29 @@ use rustls_pemfile as pemfile;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+/// Location of the pinned server certificate
+pub const DEFAULT_CERT_PATH: &str = "certs/server.pem";
 
 pub struct SecureHttpClient {
-    client: Client,
+    client: Arc<Mutex<Client>>,
     cert_path: String,
 }
 
-impl SecureHttpClient {
-    pub fn new<P: AsRef<Path>>(cert_path: P) -> anyhow::Result<Self> {
-        let path = cert_path.as_ref().to_owned();
+impl Clone for SecureHttpClient {
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client.clone(),
+            cert_path: self.cert_path.clone(),
+        }
+    }
+}
 
+impl SecureHttpClient {
+    fn build_client<P: AsRef<Path>>(path: P) -> anyhow::Result<Client> {
         let mut store = RootCertStore::empty();
         let file = File::open(&path)?;
         let mut reader = BufReader::new(file);
@@ -35,31 +48,86 @@ impl SecureHttpClient {
             .https_only(true)
             .min_tls_version(reqwest::tls::Version::TLS_1_2)
             .build()?;
+        Ok(client)
+    }
 
+    pub fn new<P: AsRef<Path>>(cert_path: P) -> anyhow::Result<Self> {
+        let path = cert_path.as_ref().to_owned();
+        let client = Self::build_client(&path)?;
         Ok(Self {
-            client,
+            client: Arc::new(Mutex::new(client)),
             cert_path: path.to_string_lossy().to_string(),
         })
     }
 
+    pub fn new_default() -> anyhow::Result<Self> {
+        Self::new(DEFAULT_CERT_PATH)
+    }
+
+    /// Initialize a client using the default certificate and optionally start
+    /// periodic updates if a URL is provided.
+    pub async fn init(
+        cert_url: Option<String>,
+        interval: Option<Duration>,
+    ) -> anyhow::Result<Arc<Self>> {
+        let client = Arc::new(Self::new_default()?);
+        if let Some(url) = cert_url.clone() {
+            // Perform an initial check on startup
+            if let Err(e) = client.update_certificates(&url).await {
+                log::error!("initial certificate update failed: {}", e);
+            }
+        }
+        if let (Some(url), Some(int)) = (cert_url, interval) {
+            client.clone().schedule_updates(url, int);
+        }
+        Ok(client)
+    }
+
     pub async fn get_text(&self, url: &str) -> reqwest::Result<String> {
-        let resp = self.client.get(url).send().await?;
+        let client = self.client.lock().await;
+        let resp = client.get(url).send().await?;
         if resp.headers().get("strict-transport-security").is_none() {
             log::warn!("HSTS header missing for {}", url);
         }
         resp.text().await
     }
 
+    pub async fn reload_certificates(&self) -> anyhow::Result<()> {
+        let client = Self::build_client(&self.cert_path)?;
+        let mut guard = self.client.lock().await;
+        *guard = client;
+        Ok(())
+    }
+
     pub async fn update_certificates(&self, url: &str) -> anyhow::Result<()> {
-        match self.client.get(url).send().await {
+        let resp = {
+            let client = self.client.lock().await;
+            client.get(url).send().await
+        };
+        match resp {
             Ok(resp) => {
                 let pem = resp.bytes().await?;
+                if let Some(parent) = Path::new(&self.cert_path).parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
                 std::fs::write(&self.cert_path, &pem)?;
+                self.reload_certificates().await?;
             }
             Err(e) => {
                 log::error!("failed to fetch new certificate: {}", e);
             }
         }
         Ok(())
+    }
+
+    pub fn schedule_updates(self: Arc<Self>, url: String, interval: Duration) {
+        tokio::spawn(async move {
+            loop {
+                if let Err(e) = self.update_certificates(&url).await {
+                    log::error!("certificate update failed: {}", e);
+                }
+                tokio::time::sleep(interval).await;
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- add certificate update scheduler in `SecureHttpClient`
- automatically reload downloaded certificates
- document how to replace `server.pem`

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861bb8a1b0c833395cbf7c419ea5fd7