### PR TITLE
Add retry status events and exponential backoff

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -22,17 +22,33 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
         // Inform the frontend that we are connecting
         if let Err(e) = app_handle.emit_all(
             "tor-status-update",
-            serde_json::json!({ "status": "CONNECTING", "bootstrapProgress": 0 }),
+            serde_json::json!({ "status": "CONNECTING", "bootstrapProgress": 0, "retryCount": 0 }),
         ) {
             log::error!("Failed to emit status update: {}", e);
         }
 
         // Perform the actual connection
-        match tor_manager.connect_with_backoff(5).await {
+        match tor_manager
+            .connect_with_backoff(5, |attempt, err| {
+                let _ = app_handle.emit_all(
+                    "tor-status-update",
+                    serde_json::json!({
+                        "status": "RETRYING",
+                        "retryCount": attempt,
+                        "errorMessage": err.to_string()
+                    }),
+                );
+            })
+            .await
+        {
             Ok(_) => {
                 if let Err(e) = app_handle.emit_all(
                     "tor-status-update",
-                    serde_json::json!({ "status": "CONNECTED", "bootstrapProgress": 100 }),
+                    serde_json::json!({
+                        "status": "CONNECTED",
+                        "bootstrapProgress": 100,
+                        "retryCount": 0
+                    }),
                 ) {
                     log::error!("Failed to emit status update: {}", e);
                 }
@@ -40,7 +56,11 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
             Err(e) => {
                 if let Err(e_emit) = app_handle.emit_all(
                     "tor-status-update",
-                    serde_json::json!({ "status": "ERROR", "errorMessage": e.to_string() }),
+                    serde_json::json!({
+                        "status": "ERROR",
+                        "errorMessage": e.to_string(),
+                        "retryCount": 0
+                    }),
                 ) {
                     log::error!("Failed to emit error status update: {}", e_emit);
                 }
@@ -55,7 +75,7 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
 pub async fn disconnect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -> Result<()> {
     if let Err(e) = app_handle.emit_all(
         "tor-status-update",
-        serde_json::json!({ "status": "DISCONNECTING" }),
+        serde_json::json!({ "status": "DISCONNECTING", "retryCount": 0 }),
     ) {
         log::error!("Failed to emit status update: {}", e);
     }
@@ -64,7 +84,7 @@ pub async fn disconnect(app_handle: tauri::AppHandle, state: State<'_, AppState>
 
     if let Err(e) = app_handle.emit_all(
         "tor-status-update",
-        serde_json::json!({ "status": "DISCONNECTED", "bootstrapProgress": 0 }),
+        serde_json::json!({ "status": "DISCONNECTED", "bootstrapProgress": 0, "retryCount": 0 }),
     ) {
         log::error!("Failed to emit status update: {}", e);
     }

--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -53,7 +53,7 @@ async fn connect_with_backoff_success() {
     MockTorClient::push_result(Err("fail".into()));
     MockTorClient::push_result(Ok(MockTorClient::default()));
     let manager: TorManager<MockTorClient> = TorManager::new();
-    let res = manager.connect_with_backoff(5).await;
+    let res = manager.connect_with_backoff(5, |_a, _e| {}).await;
     assert!(res.is_ok());
 }
 
@@ -62,7 +62,7 @@ async fn connect_with_backoff_error() {
     MockTorClient::push_result(Err("e1".into()));
     MockTorClient::push_result(Err("e2".into()));
     let manager: TorManager<MockTorClient> = TorManager::new();
-    let res = manager.connect_with_backoff(1).await;
+    let res = manager.connect_with_backoff(1, |_a, _e| {}).await;
     assert!(matches!(res, Err(Error::Bootstrap(_))));
 }
 
@@ -72,7 +72,7 @@ async fn connect_when_already_connected() {
     MockTorClient::push_result(Ok(MockTorClient::default()));
     let manager: TorManager<MockTorClient> = TorManager::new();
     manager.connect().await.unwrap();
-    let res = manager.connect_with_backoff(0).await;
+    let res = manager.connect_with_backoff(0, |_a, _e| {}).await;
     assert!(matches!(res, Err(Error::AlreadyConnected)));
 }
 

--- a/src/lib/components/ActionCard.svelte
+++ b/src/lib/components/ActionCard.svelte
@@ -47,21 +47,27 @@
 		}
 	}
 
-	$: isConnected = $torStore.status === 'CONNECTED';
-	$: isStopped = $torStore.status === 'DISCONNECTED';
-	$: isConnecting = $torStore.status === 'CONNECTING';
-	$: isDisconnecting = $torStore.status === 'DISCONNECTING';
+        $: isConnected = $torStore.status === 'CONNECTED';
+        $: isStopped = $torStore.status === 'DISCONNECTED';
+        $: isConnecting = $torStore.status === 'CONNECTING' || $torStore.status === 'RETRYING';
+        $: isRetrying = $torStore.status === 'RETRYING';
+        $: isDisconnecting = $torStore.status === 'DISCONNECTING';
 
 </script>
 
 <div class="bg-black/20 rounded-xl p-6">
 	<!-- Error Message -->
-	{#if $torStore.errorMessage}
-		<div class="mb-4 p-3 bg-red-900/30 border border-red-700/50 text-red-300 rounded-lg flex items-center gap-2">
-			<AlertCircle size={16} />
-			<span>{$torStore.errorMessage}</span>
-		</div>
-	{/if}
+        {#if $torStore.errorMessage}
+                <div class="mb-4 p-3 bg-red-900/30 border border-red-700/50 text-red-300 rounded-lg flex items-center gap-2">
+                        <AlertCircle size={16} />
+                        <span>
+                                {$torStore.errorMessage}
+                                {#if isRetrying}
+                                        (retry {$torStore.retryCount})
+                                {/if}
+                        </span>
+                </div>
+        {/if}
 
 	<!-- Four Buttons Layout -->
 	<div class="grid grid-cols-4 gap-3">
@@ -78,8 +84,12 @@
 				class="py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 transition-all duration-300 ease-in-out text-sm bg-yellow-600/20 text-yellow-400 border border-yellow-500/30 opacity-75 cursor-not-allowed"
 				disabled={true}
 			>
-				<div class="animate-spin"><RefreshCw size={16} /></div>
-				Connecting...
+                                <div class="animate-spin"><RefreshCw size={16} /></div>
+                                {#if isRetrying}
+                                        Retrying...
+                                {:else}
+                                        Connecting...
+                                {/if}
 			</button>
 		{:else if isConnected}
 			<button

--- a/src/lib/stores/torStore.ts
+++ b/src/lib/stores/torStore.ts
@@ -1,26 +1,38 @@
 import { writable } from 'svelte/store';
 import { listen } from '@tauri-apps/api/event';
 
-export type TorStatus = 'DISCONNECTED' | 'CONNECTING' | 'CONNECTED' | 'DISCONNECTING' | 'ERROR';
+export type TorStatus =
+    | 'DISCONNECTED'
+    | 'CONNECTING'
+    | 'RETRYING'
+    | 'CONNECTED'
+    | 'DISCONNECTING'
+    | 'ERROR';
 
 export interface TorState {
     status: TorStatus;
     bootstrapProgress: number;
     errorMessage: string | null;
+    retryCount: number;
 }
 
 function createTorStore() {
-    const initialState: TorState = {
-        status: 'DISCONNECTED',
-        bootstrapProgress: 0,
-        errorMessage: null,
-    };
+        const initialState: TorState = {
+            status: 'DISCONNECTED',
+            bootstrapProgress: 0,
+            errorMessage: null,
+            retryCount: 0,
+        };
 
     const { subscribe, update, set } = writable<TorState>(initialState);
 
     // Listen for status updates from the Rust backend
     listen<TorState>('tor-status-update', (event) => {
-        update(state => ({ ...state, ...event.payload }));
+        update(state => ({
+            ...state,
+            ...event.payload,
+            retryCount: event.payload.retryCount ?? (event.payload.status === 'CONNECTED' ? 0 : state.retryCount)
+        }));
     });
 
     return {


### PR DESCRIPTION
## Summary
- emit retry information during Tor connection attempts
- update TorManager with configurable backoff
- show retry attempts in the UI and store
- adjust unit tests for new API

## Testing
- `npm run check` *(fails: svelte-kit not found)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861bb8a0df88333a61d8c0b0836fcbb