### PR TITLE
Add traffic stats

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -67,3 +67,10 @@ Errors from the backend are emitted through the `tor-status-update` event. The m
 - `Identity` – refreshing the Tor identity was unsuccessful.
 
 The serialized error message is provided in the event's `errorMessage` field so the frontend can display user-friendly feedback.
+
+## 6. Traffic Statistics
+
+Version 2.2 introduces live traffic counters. `TorManager` exposes the total bytes
+sent and received via `traffic_stats()`, and the `get_traffic_stats` Tauri command
+passes these values to the frontend. The main status card now periodically
+displays the aggregate traffic in megabytes.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,6 +3,13 @@ use crate::state::AppState;
 use serde::Serialize;
 use tauri::{Manager, State};
 
+/// Total bytes sent and received through Tor.
+#[derive(Serialize, Clone)]
+pub struct TrafficStats {
+    pub bytes_sent: u64,
+    pub bytes_received: u64,
+}
+
 /// Information about a single relay in the active circuit.
 ///
 /// `country` is an ISO 3166-1 alpha-2 code derived from the relay's IP address.
@@ -117,6 +124,15 @@ pub async fn get_isolated_circuit(
 #[tauri::command]
 pub async fn set_exit_country(state: State<'_, AppState>, country: Option<String>) -> Result<()> {
     state.tor_manager.set_exit_country(country).await
+}
+
+#[tauri::command]
+pub async fn get_traffic_stats(state: State<'_, AppState>) -> Result<TrafficStats> {
+    let stats = state.tor_manager.traffic_stats().await?;
+    Ok(TrafficStats {
+        bytes_sent: stats.bytes_sent,
+        bytes_received: stats.bytes_received,
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub fn run() {
             commands::get_active_circuit,
             commands::get_isolated_circuit,
             commands::set_exit_country,
+            commands::get_traffic_stats,
             commands::get_logs,
             commands::clear_logs,
             commands::get_log_file_path

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,49 +11,77 @@
 
 	import { onMount } from 'svelte';
 
-	let activeCircuit: any[] = [];
-	let circuitInterval: any = null;
+        let activeCircuit: any[] = [];
+        let circuitInterval: any = null;
+        let trafficInterval: any = null;
+        let totalTrafficMB = 0;
 
-	async function fetchCircuit() {
-		if ($torStore.status === 'CONNECTED') {
-			try {
-				activeCircuit = await invoke('get_active_circuit');
-			} catch (e) {
-				console.error("Failed to get active circuit:", e);
-				activeCircuit = [];
-			}
-		} else {
-			activeCircuit = [];
-		}
-	}
+        async function fetchCircuit() {
+                if ($torStore.status === 'CONNECTED') {
+                        try {
+                                activeCircuit = await invoke('get_active_circuit');
+                        } catch (e) {
+                                console.error("Failed to get active circuit:", e);
+                                activeCircuit = [];
+                        }
+                } else {
+                        activeCircuit = [];
+                }
+        }
+
+        async function fetchTraffic() {
+                if ($torStore.status === 'CONNECTED') {
+                        try {
+                                const stats = await invoke('get_traffic_stats');
+                                const bytes = stats.bytes_sent + stats.bytes_received;
+                                totalTrafficMB = Math.round(bytes / 1_000_000);
+                        } catch (e) {
+                                console.error('Failed to get traffic stats:', e);
+                                totalTrafficMB = 0;
+                        }
+                } else {
+                        totalTrafficMB = 0;
+                }
+        }
 
 	// Fetch circuit info periodically when connected
-	$: if ($torStore.status === 'CONNECTED' && !circuitInterval) {
-		fetchCircuit(); // initial fetch
-		circuitInterval = setInterval(fetchCircuit, 5000); // refresh every 5 seconds
-	} else if ($torStore.status !== 'CONNECTED' && circuitInterval) {
-		clearInterval(circuitInterval);
-		circuitInterval = null;
-		activeCircuit = [];
-	}
+        $: if ($torStore.status === 'CONNECTED' && !circuitInterval) {
+                fetchCircuit();
+                circuitInterval = setInterval(fetchCircuit, 5000);
+        } else if ($torStore.status !== 'CONNECTED' && circuitInterval) {
+                clearInterval(circuitInterval);
+                circuitInterval = null;
+                activeCircuit = [];
+        }
 
-	onMount(() => {
-		return () => {
-			// Ensure interval is cleared on component unmount
-			if (circuitInterval) {
-				clearInterval(circuitInterval);
-			}
-		};
-	});
+        $: if ($torStore.status === 'CONNECTED' && !trafficInterval) {
+                fetchTraffic();
+                trafficInterval = setInterval(fetchTraffic, 5000);
+        } else if ($torStore.status !== 'CONNECTED' && trafficInterval) {
+                clearInterval(trafficInterval);
+                trafficInterval = null;
+                totalTrafficMB = 0;
+        }
+
+        onMount(() => {
+                return () => {
+                        if (circuitInterval) {
+                                clearInterval(circuitInterval);
+                        }
+                        if (trafficInterval) {
+                                clearInterval(trafficInterval);
+                        }
+                };
+        });
 </script>
 
 <div class="p-6 max-w-6xl mx-auto">
 	<div class="bg-white/20 backdrop-blur-xl rounded-[32px] border border-white/20 p-6 flex flex-col gap-2">
 		<StatusCard
-			status={$torStore.status}
-			totalTrafficMB={0}
-			pingMs={undefined}
-		/>
+                        status={$torStore.status}
+                        totalTrafficMB={totalTrafficMB}
+                        pingMs={undefined}
+                />
 
 		<TorChain
 			isConnected={$torStore.status === 'CONNECTED'}


### PR DESCRIPTION
## Summary
- expose total bytes sent/received from arti-client through `TorManager`
- new `get_traffic_stats` Tauri command
- refresh frontend to poll traffic totals and show them in the status card
- document the new traffic stats feature

## Testing
- `cargo check` *(fails: glib-sys missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861be3a613083339ba19d066e2dee66