### PR TITLE
Automatic certificate refresh

### DIFF
--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -9,3 +9,11 @@ Torwell84 uses certificate pinning to defend against man-in-the-middle attacks. 
 4. If the download fails, the previous certificate remains in place and continues to be used.
 
 This process ensures that the client always validates TLS connections against a known certificate while still allowing updates when required.
+
+## Automatic Certificate Updates
+
+`SecureHttpClient` checks for a new certificate each time the application
+starts. The request uses the currently pinned certificate for validation.
+Updated PEM files are saved to `src-tauri/certs/server.pem` and the HTTP client
+reloads them immediately, so a restart is unnecessary. Periodic update checks
+reuse the same mechanism.


### PR DESCRIPTION
## Summary
- fetch certificate updates on startup
- keep certificates in `src-tauri/certs` and use default URL
- document how automatic updates work

## Testing
- `cargo test --quiet` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861be3b2fd88333b91cd9397b196f43