### PR TITLE
Add retry delay tracking

### DIFF
--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -84,7 +84,7 @@ impl<C: TorClientBehavior> TorManager<C> {
 
     pub async fn connect_with_backoff<F>(&self, max_retries: u32, mut on_retry: F) -> Result<()>
     where
-        F: FnMut(u32, &Error) + Send,
+        F: FnMut(u32, std::time::Duration, &Error) + Send,
     {
         let mut attempt = 0;
         let mut delay = INITIAL_BACKOFF;
@@ -92,8 +92,8 @@ impl<C: TorClientBehavior> TorManager<C> {
             match self.connect_once().await {
                 Ok(_) => return Ok(()),
                 Err(e) => {
-                    on_retry(attempt + 1, &e);
                     attempt += 1;
+                    on_retry(attempt, delay, &e);
                     if attempt > max_retries {
                         return Err(e);
                     }

--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -53,7 +53,7 @@ async fn connect_with_backoff_success() {
     MockTorClient::push_result(Err("fail".into()));
     MockTorClient::push_result(Ok(MockTorClient::default()));
     let manager: TorManager<MockTorClient> = TorManager::new();
-    let res = manager.connect_with_backoff(5, |_a, _e| {}).await;
+    let res = manager.connect_with_backoff(5, |_a, _d, _e| {}).await;
     assert!(res.is_ok());
 }
 
@@ -62,7 +62,7 @@ async fn connect_with_backoff_error() {
     MockTorClient::push_result(Err("e1".into()));
     MockTorClient::push_result(Err("e2".into()));
     let manager: TorManager<MockTorClient> = TorManager::new();
-    let res = manager.connect_with_backoff(1, |_a, _e| {}).await;
+    let res = manager.connect_with_backoff(1, |_a, _d, _e| {}).await;
     assert!(matches!(res, Err(Error::Bootstrap(_))));
 }
 
@@ -72,7 +72,7 @@ async fn connect_when_already_connected() {
     MockTorClient::push_result(Ok(MockTorClient::default()));
     let manager: TorManager<MockTorClient> = TorManager::new();
     manager.connect().await.unwrap();
-    let res = manager.connect_with_backoff(0, |_a, _e| {}).await;
+    let res = manager.connect_with_backoff(0, |_a, _d, _e| {}).await;
     assert!(matches!(res, Err(Error::AlreadyConnected)));
 }
 

--- a/src/lib/components/ActionCard.svelte
+++ b/src/lib/components/ActionCard.svelte
@@ -63,7 +63,7 @@
                         <span>
                                 {$torStore.errorMessage}
                                 {#if isRetrying}
-                                        (retry {$torStore.retryCount})
+                                        (retry {$torStore.retryCount} in {$torStore.retryDelay}s)
                                 {/if}
                         </span>
                 </div>
@@ -86,7 +86,7 @@
 			>
                                 <div class="animate-spin"><RefreshCw size={16} /></div>
                                 {#if isRetrying}
-                                        Retrying...
+                                        Retrying in {$torStore.retryDelay}s (attempt {$torStore.retryCount})
                                 {:else}
                                         Connecting...
                                 {/if}

--- a/src/lib/components/IdlePanel.svelte
+++ b/src/lib/components/IdlePanel.svelte
@@ -1,6 +1,8 @@
 <script>
-	export let connectionProgress = 0; // 0-100
-	export let currentStatus = 'Idle'; // Current Tor status
+        export let connectionProgress = 0; // 0-100
+        export let currentStatus = 'Idle'; // Current Tor status
+        export let retryCount = 0;
+        export let retryDelay = 0;
 
 	// Animation for status text changes
 	let isAnimating = false;
@@ -26,12 +28,15 @@
 		</div>
 		
 		<!-- Animated Status Text -->
-		<div class="text-center relative h-4 flex items-center justify-center">
-			<p 
-				class="text-xs font-medium text-white absolute transition-all duration-300 {isAnimating ? 'opacity-0 transform scale-95' : 'opacity-100 transform scale-100'}"
-			>
-				{currentStatus}
-			</p>
-		</div>
+                <div class="text-center relative h-4 flex items-center justify-center">
+                        <p
+                                class="text-xs font-medium text-white absolute transition-all duration-300 {isAnimating ? 'opacity-0 transform scale-95' : 'opacity-100 transform scale-100'}"
+                        >
+                                {currentStatus}
+                        </p>
+                </div>
+                {#if currentStatus === 'RETRYING'}
+                        <p class="text-xs text-yellow-300">retry {retryCount} in {retryDelay}s</p>
+                {/if}
 	</div>
 </div>

--- a/src/lib/stores/torStore.ts
+++ b/src/lib/stores/torStore.ts
@@ -14,6 +14,7 @@ export interface TorState {
     bootstrapProgress: number;
     errorMessage: string | null;
     retryCount: number;
+    retryDelay: number;
 }
 
 function createTorStore() {
@@ -22,6 +23,7 @@ function createTorStore() {
             bootstrapProgress: 0,
             errorMessage: null,
             retryCount: 0,
+            retryDelay: 0,
         };
 
     const { subscribe, update, set } = writable<TorState>(initialState);
@@ -31,7 +33,8 @@ function createTorStore() {
         update(state => ({
             ...state,
             ...event.payload,
-            retryCount: event.payload.retryCount ?? (event.payload.status === 'CONNECTED' ? 0 : state.retryCount)
+            retryCount: event.payload.retryCount ?? ([ 'CONNECTED', 'DISCONNECTED', 'ERROR' ].includes(event.payload.status as string) ? 0 : state.retryCount),
+            retryDelay: event.payload.retryDelay ?? ([ 'CONNECTED', 'DISCONNECTED', 'ERROR' ].includes(event.payload.status as string) ? 0 : state.retryDelay)
         }));
     });
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -70,6 +70,8 @@
                 <IdlePanel
                         connectionProgress={$torStore.bootstrapProgress}
                         currentStatus={$torStore.status}
+                        retryCount={$torStore.retryCount}
+                        retryDelay={$torStore.retryDelay}
                 />
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- include delay in `connect_with_backoff` retry callback
- surface retry delay info in connect/disconnect commands
- store retry delay in the tor store
- show retry progress in `ActionCard` and `IdlePanel`
- adjust page to forward retry data
- update tests for new callback signature

## Testing
- `bun run check`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861be3c0434833381e13df188dca75b