### PR TITLE
Add more command tests

### DIFF
--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -57,3 +57,104 @@ async fn command_get_status() {
     let status = commands::get_status(state).await.unwrap();
     assert_eq!(status, "DISCONNECTED");
 }
+
+#[tokio::test]
+async fn command_disconnect_not_connected() {
+    let mut app = tauri::test::mock_app();
+    app.manage(mock_state());
+    let received = Arc::new(StdMutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    let _handler = app.listen_global("tor-status-update", move |event| {
+        if let Some(p) = event.payload() {
+            recv_clone.lock().unwrap().push(p.to_string());
+        }
+    });
+    let state = app.state::<AppState<MockTorClient>>();
+    let res = commands::disconnect(app.handle(), state).await;
+    assert!(matches!(res, Err(Error::NotConnected)));
+    let events = received.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    let payload: serde_json::Value = serde_json::from_str(&events[0]).unwrap();
+    assert_eq!(payload["status"], "DISCONNECTING");
+}
+
+#[tokio::test]
+async fn command_disconnect_connected() {
+    MockTorClient::push_result(Ok(MockTorClient::default()));
+    let mut app = tauri::test::mock_app();
+    let state = mock_state();
+    state.tor_manager.connect().await.unwrap();
+    app.manage(state);
+    let received = Arc::new(StdMutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    let _handler = app.listen_global("tor-status-update", move |event| {
+        if let Some(p) = event.payload() {
+            recv_clone.lock().unwrap().push(p.to_string());
+        }
+    });
+    let state = app.state::<AppState<MockTorClient>>();
+    commands::disconnect(app.handle(), state).await.unwrap();
+    let events = received.lock().unwrap();
+    assert_eq!(events.len(), 2);
+    let first: serde_json::Value = serde_json::from_str(&events[0]).unwrap();
+    let second: serde_json::Value = serde_json::from_str(&events[1]).unwrap();
+    assert_eq!(first["status"], "DISCONNECTING");
+    assert_eq!(second["status"], "DISCONNECTED");
+}
+
+#[tokio::test]
+async fn command_new_identity_success() {
+    MockTorClient::push_result(Ok(MockTorClient { reconfigure_ok: true, build_ok: true }));
+    let mut app = tauri::test::mock_app();
+    let state = mock_state();
+    state.tor_manager.connect().await.unwrap();
+    app.manage(state);
+    let received = Arc::new(StdMutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    let _handler = app.listen_global("tor-status-update", move |event| {
+        if let Some(p) = event.payload() {
+            recv_clone.lock().unwrap().push(p.to_string());
+        }
+    });
+    let state = app.state::<AppState<MockTorClient>>();
+    commands::new_identity(app.handle(), state).await.unwrap();
+    let events = received.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    let payload: serde_json::Value = serde_json::from_str(&events[0]).unwrap();
+    assert_eq!(payload["status"], "NEW_IDENTITY");
+}
+
+#[tokio::test]
+async fn command_new_identity_not_connected() {
+    let mut app = tauri::test::mock_app();
+    app.manage(mock_state());
+    let received = Arc::new(StdMutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    let _handler = app.listen_global("tor-status-update", move |event| {
+        if let Some(p) = event.payload() {
+            recv_clone.lock().unwrap().push(p.to_string());
+        }
+    });
+    let state = app.state::<AppState<MockTorClient>>();
+    let res = commands::new_identity(app.handle(), state).await;
+    assert!(matches!(res, Err(Error::NotConnected)));
+    assert!(received.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn command_log_retrieval() {
+    let mut app = tauri::test::mock_app();
+    let state = mock_state();
+    let _ = tokio::fs::remove_file(&state.log_file).await;
+    app.manage(state);
+    let state = app.state::<AppState<MockTorClient>>();
+    state.add_log("line1".into()).await.unwrap();
+    state.add_log("line2".into()).await.unwrap();
+    let logs = commands::get_logs(state).await.unwrap();
+    assert_eq!(logs, vec!["line1", "line2"]);
+    commands::clear_logs(state).await.unwrap();
+    let logs = commands::get_logs(state).await.unwrap();
+    assert!(logs.is_empty());
+    let path = commands::get_log_file_path(state).await.unwrap();
+    assert!(path.ends_with("test.log"));
+}


### PR DESCRIPTION
## Summary
- increase test coverage for commands
- verify disconnect and new identity events
- check log retrieval APIs

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml --tests` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861be3ca92c83338b4b8d4428eb42b8