### PR TITLE
Structured logging with level filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@types/node": "^20.10.0",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",
+    "prettier": "^3.6.2",
+    "prettier-plugin-svelte": "^3.4.0",
     "svelte": "^4.2.7",
     "svelte-check": "^3.6.0",
     "tailwindcss": "^3.3.6",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ arti-client = { version = "0.31.0", features = ["tokio", "rpc", "full", "experim
 tor-rtcompat = { version = "0.31.0" }
 tokio = { version = "1", features = ["full"] }
 futures-util = "0.3"
+chrono = { version = "0.4", features = ["serde"] }
 tor-circmgr = "0.31.0"
 tor-dirmgr = "0.31.0"
 tor-netdir = "0.31.0"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::state::AppState;
+use crate::state::{AppState, LogEntry};
 use serde::Serialize;
 use tauri::{Manager, State};
 
@@ -159,7 +159,7 @@ pub async fn new_identity(app_handle: tauri::AppHandle, state: State<'_, AppStat
     Ok(())
 }
 #[tauri::command]
-pub async fn get_logs(state: State<'_, AppState>) -> Result<Vec<String>> {
+pub async fn get_logs(state: State<'_, AppState>) -> Result<Vec<LogEntry>> {
     state.read_logs().await
 }
 

--- a/src/lib/components/LogsModal.svelte
+++ b/src/lib/components/LogsModal.svelte
@@ -16,12 +16,14 @@
 	}
 
         let activeTab = 'all';
+        let levelFilter = 'all';
         let logs: LogEntry[] = [];
         let isLoading = false;
         let isClearing = false;
         let logFilePath = '';
 
-	$: filteredLogs = activeTab === 'all' ? logs : logs.filter(log => log.type === activeTab);
+        $: filteredByType = activeTab === 'all' ? logs : logs.filter(log => log.type === activeTab);
+        $: filteredLogs = levelFilter === 'all' ? filteredByType : filteredByType.filter(log => log.level === levelFilter);
 
         $: if (show) {
                 loadLogs();
@@ -120,18 +122,28 @@
 			</div>
 
 			<!-- Tabs -->
-			<div class="flex border-b border-white/10">
-				{#each [{ id: 'all', label: 'All Logs' }, { id: 'connection', label: 'Connection Logs' }, { id: 'system', label: 'System Logs' }] as tab}
-					<button
-						class="px-6 py-3 text-sm font-medium transition-colors {activeTab === tab.id
-							? 'text-blue-400 border-b-2 border-blue-400'
-							: 'text-gray-400 hover:text-white'}"
-						on:click={() => (activeTab = tab.id)}
-					>
-						{tab.label}
-					</button>
-				{/each}
-			</div>
+                        <div class="flex border-b border-white/10">
+                                {#each [{ id: 'all', label: 'All Logs' }, { id: 'connection', label: 'Connection Logs' }, { id: 'system', label: 'System Logs' }] as tab}
+                                        <button
+                                                class="px-6 py-3 text-sm font-medium transition-colors {activeTab === tab.id
+                                                        ? 'text-blue-400 border-b-2 border-blue-400'
+                                                        : 'text-gray-400 hover:text-white'}"
+                                                on:click={() => (activeTab = tab.id)}
+                                        >
+                                                {tab.label}
+                                        </button>
+                                {/each}
+                        </div>
+
+                        <div class="flex items-center gap-2 p-2 border-b border-white/10">
+                                <label class="text-sm text-gray-400">Level:</label>
+                                <select bind:value={levelFilter} class="bg-gray-800 text-white text-sm rounded p-1">
+                                        <option value="all">All</option>
+                                        <option value="INFO">Info</option>
+                                        <option value="WARN">Warn</option>
+                                        <option value="ERROR">Error</option>
+                                </select>
+                        </div>
 
 			<!-- Log Content -->
 			<div class="p-6 max-h-96 overflow-y-auto">
@@ -147,11 +159,11 @@
 				{:else}
 					<div class="space-y-2">
 						<div class="text-sm text-gray-300 font-mono">
-							{#each filteredLogs as log}
-								<div class="{log.level === 'ERROR' ? 'text-red-400' : log.level === 'WARN' ? 'text-yellow-400' : log.type === 'connection' ? 'text-green-400' : 'text-blue-400'}">
-									[{log.timestamp}] {log.message}
-								</div>
-							{/each}
+                                                        {#each filteredLogs as log}
+                                                                <div class="{log.level === 'ERROR' ? 'text-red-400' : log.level === 'WARN' ? 'text-yellow-400' : 'text-blue-400'}">
+                                                                        [{log.timestamp}] [{log.level}] {log.message}
+                                                                </div>
+                                                        {/each}
 						</div>
 					</div>
 				{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,115 +1,113 @@
 <script lang="ts">
-	import StatusCard from '$lib/components/StatusCard.svelte';
-	import TorChain from '$lib/components/TorChain.svelte';
-	import ActionCard from '$lib/components/ActionCard.svelte';
-	import IdlePanel from '$lib/components/IdlePanel.svelte';
-	import LogsModal from '$lib/components/LogsModal.svelte';
-	import SettingsModal from '$lib/components/SettingsModal.svelte';
-	import { uiStore } from '$lib/stores/uiStore';
-	import { torStore } from '$lib/stores/torStore';
-	import { invoke } from '@tauri-apps/api/tauri';
+  import StatusCard from "$lib/components/StatusCard.svelte";
+  import TorChain from "$lib/components/TorChain.svelte";
+  import ActionCard from "$lib/components/ActionCard.svelte";
+  import IdlePanel from "$lib/components/IdlePanel.svelte";
+  import LogsModal from "$lib/components/LogsModal.svelte";
+  import SettingsModal from "$lib/components/SettingsModal.svelte";
+  import { uiStore } from "$lib/stores/uiStore";
+  import { torStore } from "$lib/stores/torStore";
+  import { invoke } from "@tauri-apps/api/tauri";
 
-	import { onMount } from 'svelte';
+  import { onMount } from "svelte";
 
-        let activeCircuit: any[] = [];
-        let circuitInterval: any = null;
-        let trafficInterval: any = null;
-        let totalTrafficMB = 0;
+  let activeCircuit: any[] = [];
+  let circuitInterval: any = null;
+  let trafficInterval: any = null;
+  let totalTrafficMB = 0;
 
-        async function fetchCircuit() {
-                if ($torStore.status === 'CONNECTED') {
-                        try {
-                                activeCircuit = await invoke('get_active_circuit');
-                        } catch (e) {
-                                console.error("Failed to get active circuit:", e);
-                                activeCircuit = [];
-                        }
-                } else {
-                        activeCircuit = [];
-                }
-        }
+  async function fetchCircuit() {
+    if ($torStore.status === "CONNECTED") {
+      try {
+        activeCircuit = await invoke("get_active_circuit");
+      } catch (e) {
+        console.error("Failed to get active circuit:", e);
+        activeCircuit = [];
+      }
+    } else {
+      activeCircuit = [];
+    }
+  }
 
-        async function fetchTraffic() {
-                if ($torStore.status === 'CONNECTED') {
-                        try {
-                                const stats = await invoke('get_traffic_stats');
-                                const bytes = stats.bytes_sent + stats.bytes_received;
-                                totalTrafficMB = Math.round(bytes / 1_000_000);
-                        } catch (e) {
-                                console.error('Failed to get traffic stats:', e);
-                                totalTrafficMB = 0;
-                        }
-                } else {
-                        totalTrafficMB = 0;
-                }
-        }
+  async function fetchTraffic() {
+    if ($torStore.status === "CONNECTED") {
+      try {
+        const stats = await invoke<any>("get_traffic_stats");
+        const bytes = stats.bytes_sent + stats.bytes_received;
+        totalTrafficMB = Math.round(bytes / 1_000_000);
+      } catch (e) {
+        console.error("Failed to get traffic stats:", e);
+        totalTrafficMB = 0;
+      }
+    } else {
+      totalTrafficMB = 0;
+    }
+  }
 
-	// Fetch circuit info periodically when connected
-        $: if ($torStore.status === 'CONNECTED' && !circuitInterval) {
-                fetchCircuit();
-                circuitInterval = setInterval(fetchCircuit, 5000);
-        } else if ($torStore.status !== 'CONNECTED' && circuitInterval) {
-                clearInterval(circuitInterval);
-                circuitInterval = null;
-                activeCircuit = [];
-        }
+  // Fetch circuit info periodically when connected
+  $: if ($torStore.status === "CONNECTED" && !circuitInterval) {
+    fetchCircuit();
+    circuitInterval = setInterval(fetchCircuit, 5000);
+  } else if ($torStore.status !== "CONNECTED" && circuitInterval) {
+    clearInterval(circuitInterval);
+    circuitInterval = null;
+    activeCircuit = [];
+  }
 
-        $: if ($torStore.status === 'CONNECTED' && !trafficInterval) {
-                fetchTraffic();
-                trafficInterval = setInterval(fetchTraffic, 5000);
-        } else if ($torStore.status !== 'CONNECTED' && trafficInterval) {
-                clearInterval(trafficInterval);
-                trafficInterval = null;
-                totalTrafficMB = 0;
-        }
+  $: if ($torStore.status === "CONNECTED" && !trafficInterval) {
+    fetchTraffic();
+    trafficInterval = setInterval(fetchTraffic, 5000);
+  } else if ($torStore.status !== "CONNECTED" && trafficInterval) {
+    clearInterval(trafficInterval);
+    trafficInterval = null;
+    totalTrafficMB = 0;
+  }
 
-        onMount(() => {
-                return () => {
-                        if (circuitInterval) {
-                                clearInterval(circuitInterval);
-                        }
-                        if (trafficInterval) {
-                                clearInterval(trafficInterval);
-                        }
-                };
-        });
+  onMount(() => {
+    return () => {
+      if (circuitInterval) {
+        clearInterval(circuitInterval);
+      }
+      if (trafficInterval) {
+        clearInterval(trafficInterval);
+      }
+    };
+  });
 </script>
 
 <div class="p-6 max-w-6xl mx-auto">
-	<div class="bg-white/20 backdrop-blur-xl rounded-[32px] border border-white/20 p-6 flex flex-col gap-2">
-		<StatusCard
-                        status={$torStore.status}
-                        totalTrafficMB={totalTrafficMB}
-                        pingMs={undefined}
-                />
+  <div
+    class="bg-white/20 backdrop-blur-xl rounded-[32px] border border-white/20 p-6 flex flex-col gap-2"
+  >
+    <StatusCard status={$torStore.status} {totalTrafficMB} pingMs={undefined} />
 
-		<TorChain
-			isConnected={$torStore.status === 'CONNECTED'}
-			isActive={$torStore.status === 'CONNECTED'}
-			nodeData={activeCircuit}
-			cloudflareEnabled={false}
-		/>
+    <TorChain
+      isConnected={$torStore.status === "CONNECTED"}
+      isActive={$torStore.status === "CONNECTED"}
+      nodeData={activeCircuit}
+      cloudflareEnabled={false}
+    />
 
-		<ActionCard
-			on:openLogs={() => uiStore.actions.openLogsModal()}
-			on:openSettings={() => uiStore.actions.openSettingsModal()}
-		/>
+    <ActionCard
+      on:openLogs={() => uiStore.actions.openLogsModal()}
+      on:openSettings={() => uiStore.actions.openSettingsModal()}
+    />
 
-                <IdlePanel
-                        connectionProgress={$torStore.bootstrapProgress}
-                        currentStatus={$torStore.status}
-                        retryCount={$torStore.retryCount}
-                        retryDelay={$torStore.retryDelay}
-                />
-	</div>
+    <IdlePanel
+      connectionProgress={$torStore.bootstrapProgress}
+      currentStatus={$torStore.status}
+      retryCount={$torStore.retryCount}
+      retryDelay={$torStore.retryDelay}
+    />
+  </div>
 </div>
 
-<LogsModal 
-	bind:show={$uiStore.isLogsModalOpen} 
-	on:close={() => uiStore.actions.closeLogsModal()}
+<LogsModal
+  bind:show={$uiStore.isLogsModalOpen}
+  on:close={() => uiStore.actions.closeLogsModal()}
 />
 
 <SettingsModal
-		bind:show={$uiStore.isSettingsModalOpen}
-		on:close={() => uiStore.actions.closeSettingsModal()}
-	/>
+  bind:show={$uiStore.isSettingsModalOpen}
+  on:close={() => uiStore.actions.closeSettingsModal()}
+/>


### PR DESCRIPTION
## Summary
- introduce `LogEntry` struct with level and timestamp
- store logs in JSON format
- expose structured logs from `get_logs`
- add log level filtering and colour coding in `LogsModal`
- minor TypeScript fix for traffic stats

## Testing
- `pnpm run check`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68623dbf2f6c83339cdba1ca41df6a06