### PR TITLE
Add bootstrap progress messages

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -29,7 +29,7 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
         // Inform the frontend that we are connecting
         if let Err(e) = app_handle.emit_all(
             "tor-status-update",
-            serde_json::json!({ "status": "CONNECTING", "bootstrapProgress": 0, "retryCount": 0, "retryDelay": 0 }),
+            serde_json::json!({ "status": "CONNECTING", "bootstrapProgress": 0, "bootstrapMessage": "", "retryCount": 0, "retryDelay": 0 }),
         ) {
             log::error!("Failed to emit status update: {}", e);
         }
@@ -49,12 +49,13 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
                         }),
                     );
                 },
-                |progress| {
+                |progress, msg| {
                     let _ = app_handle.emit_all(
                         "tor-status-update",
                         serde_json::json!({
                             "status": "CONNECTING",
-                            "bootstrapProgress": progress
+                            "bootstrapProgress": progress,
+                            "bootstrapMessage": msg
                         }),
                     );
                 },
@@ -67,6 +68,7 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
                     serde_json::json!({
                         "status": "CONNECTED",
                         "bootstrapProgress": 100,
+                        "bootstrapMessage": "done",
                         "retryCount": 0, "retryDelay": 0
                     }),
                 ) {
@@ -79,6 +81,7 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
                     serde_json::json!({
                         "status": "ERROR",
                         "errorMessage": e.to_string(),
+                        "bootstrapMessage": "",
                         "retryCount": 0, "retryDelay": 0
                     }),
                 ) {
@@ -95,7 +98,7 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
 pub async fn disconnect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -> Result<()> {
     if let Err(e) = app_handle.emit_all(
         "tor-status-update",
-        serde_json::json!({ "status": "DISCONNECTING", "retryCount": 0, "retryDelay": 0 }),
+        serde_json::json!({ "status": "DISCONNECTING", "bootstrapMessage": "", "retryCount": 0, "retryDelay": 0 }),
     ) {
         log::error!("Failed to emit status update: {}", e);
     }
@@ -104,7 +107,7 @@ pub async fn disconnect(app_handle: tauri::AppHandle, state: State<'_, AppState>
 
     if let Err(e) = app_handle.emit_all(
         "tor-status-update",
-        serde_json::json!({ "status": "DISCONNECTED", "bootstrapProgress": 0, "retryCount": 0, "retryDelay": 0 }),
+        serde_json::json!({ "status": "DISCONNECTED", "bootstrapProgress": 0, "bootstrapMessage": "", "retryCount": 0, "retryDelay": 0 }),
     ) {
         log::error!("Failed to emit status update: {}", e);
     }

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -36,6 +36,19 @@ impl TorClientBehavior for MockTorClient {
             .pop_front()
             .expect("no result")
     }
+    async fn create_bootstrapped_with_progress<P>(
+        config: TorClientConfig,
+        progress: &mut P,
+    ) -> std::result::Result<Self, String>
+    where
+        P: FnMut(u8, String) + Send,
+    {
+        let res = Self::create_bootstrapped(config).await;
+        if res.is_ok() {
+            progress(100, "done".into());
+        }
+        res
+    }
     fn reconfigure(&self, _config: &TorClientConfig) -> std::result::Result<(), String> {
         if self.reconfigure_ok {
             Ok(())

--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -1,8 +1,8 @@
 use once_cell::sync::Lazy;
 use std::collections::VecDeque;
 use std::sync::Mutex;
-use torwell84::tor_manager::{TorManager, TorClientBehavior, TorClientConfig};
 use torwell84::error::Error;
+use torwell84::tor_manager::{TorClientBehavior, TorClientConfig, TorManager};
 
 #[derive(Clone, Default)]
 struct MockTorClient {
@@ -34,11 +34,11 @@ impl TorClientBehavior for MockTorClient {
         progress: &mut P,
     ) -> std::result::Result<Self, String>
     where
-        P: FnMut(u8) + Send,
+        P: FnMut(u8, String) + Send,
     {
         let res = Self::create_bootstrapped(config).await;
         if res.is_ok() {
-            progress(100);
+            progress(100, "done".into());
         }
         res
     }
@@ -67,7 +67,9 @@ async fn connect_with_backoff_success() {
     MockTorClient::push_result(Err("fail".into()));
     MockTorClient::push_result(Ok(MockTorClient::default()));
     let manager: TorManager<MockTorClient> = TorManager::new();
-    let res = manager.connect_with_backoff(5, |_a, _d, _e| {}, |_| {}).await;
+    let res = manager
+        .connect_with_backoff(5, |_a, _d, _e| {}, |_| {})
+        .await;
     assert!(res.is_ok());
 }
 
@@ -76,7 +78,9 @@ async fn connect_with_backoff_error() {
     MockTorClient::push_result(Err("e1".into()));
     MockTorClient::push_result(Err("e2".into()));
     let manager: TorManager<MockTorClient> = TorManager::new();
-    let res = manager.connect_with_backoff(1, |_a, _d, _e| {}, |_| {}).await;
+    let res = manager
+        .connect_with_backoff(1, |_a, _d, _e| {}, |_| {})
+        .await;
     assert!(matches!(res, Err(Error::Bootstrap(_))));
 }
 
@@ -86,13 +90,18 @@ async fn connect_when_already_connected() {
     MockTorClient::push_result(Ok(MockTorClient::default()));
     let manager: TorManager<MockTorClient> = TorManager::new();
     manager.connect().await.unwrap();
-    let res = manager.connect_with_backoff(0, |_a, _d, _e| {}, |_| {}).await;
+    let res = manager
+        .connect_with_backoff(0, |_a, _d, _e| {}, |_| {})
+        .await;
     assert!(matches!(res, Err(Error::AlreadyConnected)));
 }
 
 #[tokio::test]
 async fn new_identity_success() {
-    MockTorClient::push_result(Ok(MockTorClient { reconfigure_ok: true, build_ok: true }));
+    MockTorClient::push_result(Ok(MockTorClient {
+        reconfigure_ok: true,
+        build_ok: true,
+    }));
     let manager: TorManager<MockTorClient> = TorManager::new();
     manager.connect().await.unwrap();
     assert!(manager.new_identity().await.is_ok());
@@ -107,7 +116,10 @@ async fn new_identity_not_connected() {
 
 #[tokio::test]
 async fn new_identity_reconfigure_error() {
-    MockTorClient::push_result(Ok(MockTorClient { reconfigure_ok: false, build_ok: true }));
+    MockTorClient::push_result(Ok(MockTorClient {
+        reconfigure_ok: false,
+        build_ok: true,
+    }));
     let manager: TorManager<MockTorClient> = TorManager::new();
     manager.connect().await.unwrap();
     let res = manager.new_identity().await;
@@ -116,7 +128,10 @@ async fn new_identity_reconfigure_error() {
 
 #[tokio::test]
 async fn new_identity_build_error() {
-    MockTorClient::push_result(Ok(MockTorClient { reconfigure_ok: true, build_ok: false }));
+    MockTorClient::push_result(Ok(MockTorClient {
+        reconfigure_ok: true,
+        build_ok: false,
+    }));
     let manager: TorManager<MockTorClient> = TorManager::new();
     manager.connect().await.unwrap();
     let res = manager.new_identity().await;

--- a/src/lib/components/IdlePanel.svelte
+++ b/src/lib/components/IdlePanel.svelte
@@ -3,6 +3,7 @@
         export let currentStatus = 'Idle'; // Current Tor status
         export let retryCount = 0;
         export let retryDelay = 0;
+        export let bootstrapMessage = '';
 
 	// Animation for status text changes
 	let isAnimating = false;
@@ -27,6 +28,9 @@
                         ></div>
                 </div>
                 <p class="text-xs text-gray-300">{Math.round(connectionProgress)}%</p>
+                {#if bootstrapMessage}
+                        <p class="text-xs text-gray-400 italic">{bootstrapMessage}</p>
+                {/if}
 		
 		<!-- Animated Status Text -->
                 <div class="text-center relative h-4 flex items-center justify-center">

--- a/src/lib/stores/torStore.ts
+++ b/src/lib/stores/torStore.ts
@@ -1,48 +1,69 @@
-import { writable } from 'svelte/store';
-import { listen } from '@tauri-apps/api/event';
+import { writable } from "svelte/store";
+import { listen } from "@tauri-apps/api/event";
 
 export type TorStatus =
-    | 'DISCONNECTED'
-    | 'CONNECTING'
-    | 'RETRYING'
-    | 'CONNECTED'
-    | 'DISCONNECTING'
-    | 'ERROR';
+  | "DISCONNECTED"
+  | "CONNECTING"
+  | "RETRYING"
+  | "CONNECTED"
+  | "DISCONNECTING"
+  | "ERROR";
 
 export interface TorState {
-    status: TorStatus;
-    bootstrapProgress: number;
-    errorMessage: string | null;
-    retryCount: number;
-    retryDelay: number;
+  status: TorStatus;
+  bootstrapProgress: number;
+  bootstrapMessage: string;
+  errorMessage: string | null;
+  retryCount: number;
+  retryDelay: number;
 }
 
 function createTorStore() {
-        const initialState: TorState = {
-            status: 'DISCONNECTED',
-            bootstrapProgress: 0,
-            errorMessage: null,
-            retryCount: 0,
-            retryDelay: 0,
-        };
+  const initialState: TorState = {
+    status: "DISCONNECTED",
+    bootstrapProgress: 0,
+    bootstrapMessage: "",
+    errorMessage: null,
+    retryCount: 0,
+    retryDelay: 0,
+  };
 
-    const { subscribe, update, set } = writable<TorState>(initialState);
+  const { subscribe, update, set } = writable<TorState>(initialState);
 
-    // Listen for status updates from the Rust backend
-    listen<TorState>('tor-status-update', (event) => {
-        update(state => ({
-            ...state,
-            ...event.payload,
-            retryCount: event.payload.retryCount ?? ([ 'CONNECTED', 'DISCONNECTED', 'ERROR' ].includes(event.payload.status as string) ? 0 : state.retryCount),
-            retryDelay: event.payload.retryDelay ?? ([ 'CONNECTED', 'DISCONNECTED', 'ERROR' ].includes(event.payload.status as string) ? 0 : state.retryDelay)
-        }));
-    });
+  // Listen for status updates from the Rust backend
+  listen<TorState>("tor-status-update", (event) => {
+    update((state) => ({
+      ...state,
+      ...event.payload,
+      retryCount:
+        event.payload.retryCount ??
+        (["CONNECTED", "DISCONNECTED", "ERROR"].includes(
+          event.payload.status as string,
+        )
+          ? 0
+          : state.retryCount),
+      retryDelay:
+        event.payload.retryDelay ??
+        (["CONNECTED", "DISCONNECTED", "ERROR"].includes(
+          event.payload.status as string,
+        )
+          ? 0
+          : state.retryDelay),
+      bootstrapMessage:
+        event.payload.bootstrapMessage ??
+        (["CONNECTED", "DISCONNECTED", "ERROR"].includes(
+          event.payload.status as string,
+        )
+          ? ""
+          : state.bootstrapMessage),
+    }));
+  });
 
-    return {
-        subscribe,
-        set,
-        update,
-    };
+  return {
+    subscribe,
+    set,
+    update,
+  };
 }
 
 export const torStore = createTorStore();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -95,6 +95,7 @@
 
     <IdlePanel
       connectionProgress={$torStore.bootstrapProgress}
+      bootstrapMessage={$torStore.bootstrapMessage}
       currentStatus={$torStore.status}
       retryCount={$torStore.retryCount}
       retryDelay={$torStore.retryDelay}


### PR DESCRIPTION
## Summary
- wire bootstrap messages through TorManager and commands
- forward progress information to the frontend store
- display bootstrap messages in IdlePanel

## Testing
- `cargo test` *(fails: `glib-2.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68624388570c8333a4bcd0d97af98353