### PR TITLE
Implement structured log docs

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -43,6 +43,8 @@ The frontend remains visually and functionally identical to the original design,
 - Automatic log rotation (max 1000 entries)
 - Commands for log retrieval and clearing
 - Logs are stored as JSON lines containing the log level, timestamp and message
+- The Logs modal in the Svelte UI lets users filter by level and highlights
+  warnings and errors with dedicated colours
 
 ### 3.3 Documentation Updates
 - Comprehensive changelog tracking

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3,6 +3,7 @@ use crate::tor_manager::{TorClientBehavior, TorManager};
 use arti_client::TorClient;
 use chrono::Utc;
 use log::Level;
+use tor_rtcompat::PreferredRuntime;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary
- document log-level filtering in the UI
- import `PreferredRuntime` for clarity in `AppState`

## Testing
- `pnpm run check` *(fails: svelte-kit missing)*
- `cargo check` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68627824cde88333a25e3e9150a39ef4