### PR TITLE
Initialize SecureHttpClient and config

### DIFF
--- a/src-tauri/certs/cert_config.json
+++ b/src-tauri/certs/cert_config.json
@@ -1,0 +1,4 @@
+{
+  "cert_path": "src-tauri/certs/server.pem",
+  "cert_url": "https://example.com/certs/server.pem"
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,9 +5,20 @@ mod state;
 mod tor_manager;
 
 use state::AppState;
+use secure_http::SecureHttpClient;
+use std::time::Duration;
 
 pub fn run() {
-    let app_state = AppState::default();
+    let http_client = tauri::async_runtime::block_on(async {
+        SecureHttpClient::init(
+            secure_http::DEFAULT_CONFIG_PATH,
+            None,
+            None,
+            Some(Duration::from_secs(60 * 60 * 24)),
+        )
+        .expect("failed to initialize http client")
+    });
+    let app_state = AppState::new(http_client);
 
     tauri::Builder::default()
         .manage(app_state)

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -9,6 +9,7 @@ use tokio::sync::Mutex;
 use log::Level;
 use torwell84::commands;
 use torwell84::error::Error;
+use torwell84::secure_http::SecureHttpClient;
 use torwell84::state::{AppState, LogEntry};
 use torwell84::tor_manager::{TorClientBehavior, TorClientConfig, TorManager};
 
@@ -69,6 +70,7 @@ impl TorClientBehavior for MockTorClient {
 fn mock_state() -> AppState<MockTorClient> {
     AppState {
         tor_manager: Arc::new(TorManager::new()),
+        http_client: Arc::new(SecureHttpClient::new_default().unwrap()),
         log_file: PathBuf::from("test.log"),
         log_lock: Arc::new(Mutex::new(())),
         max_log_lines: 1000,


### PR DESCRIPTION
## Summary
- add a default `cert_config.json`
- pass `SecureHttpClient` via `AppState`
- initialize the client on startup with a daily update schedule
- adjust tests for the new `AppState`
- add a test using the repository config file

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863156408e48333997b5803737ab1a5