### PR TITLE
Add connection timeout and retry logging

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -14,4 +14,6 @@ This guide lists common problems encountered during development and how to analy
 - The backend writes logs to a persistent file named `torwell.log` in the project directory. Older entries are trimmed once the file exceeds the configured line limit.
 - Each line of this file is a JSON object with `level`, `timestamp` and `message` fields.
 - If the UI fails to load, open the browser developer tools (`Ctrl+Shift+I`) to inspect console logs and network activity.
+- Failed connection attempts are recorded with `WARN` level. The retry counter resets when a new connection starts.
+- If `Error::Timeout` occurs, the Tor bootstrap exceeded the allowed time. Check your network or increase the limit.
 

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -18,6 +18,9 @@ pub enum Error {
     #[error("Client is already connected")]
     AlreadyConnected,
 
+    #[error("Connection timed out")]
+    Timeout,
+
     #[error("No circuit available")]
     NoCircuit,
 

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -73,6 +73,7 @@ fn mock_state() -> AppState<MockTorClient> {
         http_client: Arc::new(SecureHttpClient::new_default().unwrap()),
         log_file: PathBuf::from("test.log"),
         log_lock: Arc::new(Mutex::new(())),
+        retry_counter: Arc::new(Mutex::new(0)),
         max_log_lines: 1000,
     }
 }


### PR DESCRIPTION
## Summary
- stop `connect_with_backoff` after a total time limit
- track retries in `AppState` and log failed attempts
- document new troubleshooting tips

## Testing
- `pnpm run check` *(fails: svelte-kit not found)*
- `cargo test --quiet` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68632236ab408333bca5a081f619c176