### PR TITLE
Add tests for commands, geoip cache, and certificate init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - name: Run cargo test
         working-directory: src-tauri
-        run: cargo test --verbose
+        run: cargo test --all-targets --verbose
 
   svelte-check:
     name: Svelte Checks


### PR DESCRIPTION
## Summary
- test `set_exit_country` and `set_bridges`
- expose helpers from `TorManager` and unit test geoip cache
- cover SecureHttpClient initialization with missing config
- run `cargo test --all-targets` in CI

## Testing
- `cargo test --all-targets --quiet` *(fails: failed to run custom build command for `glib-sys v0.15.10`)*

------
https://chatgpt.com/codex/tasks/task_e_6863223787288333800a83bfdd5ee273