### PR TITLE
Add metrics reporting

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 rustls = "0.23"
 rustls-pemfile = "2"
 anyhow = "1"
+sysinfo = "0.30"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,8 +4,8 @@ mod secure_http;
 mod state;
 mod tor_manager;
 
-use state::AppState;
 use secure_http::SecureHttpClient;
+use state::AppState;
 use std::time::Duration;
 
 pub fn run() {
@@ -41,6 +41,7 @@ pub fn run() {
             commands::set_exit_country,
             commands::set_bridges,
             commands::get_traffic_stats,
+            commands::get_metrics,
             commands::get_logs,
             commands::clear_logs,
             commands::get_log_file_path

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -27,6 +27,15 @@ pub struct TrafficStats {
     pub bytes_received: u64,
 }
 
+/// Basic circuit metrics.
+#[derive(Debug, Clone)]
+pub struct CircuitMetrics {
+    /// Number of active circuits.
+    pub count: usize,
+    /// Age of the oldest circuit in seconds.
+    pub oldest_age: u64,
+}
+
 #[async_trait]
 pub trait TorClientBehavior: Send + Sync + Sized + 'static {
     async fn create_bootstrapped(config: TorClientConfig) -> std::result::Result<Self, String>;
@@ -448,6 +457,19 @@ impl TorManager {
         Ok(TrafficStats {
             bytes_sent: stats.bytes_written(),
             bytes_received: stats.bytes_read(),
+        })
+    }
+
+    /// Return number of active circuits and age of the oldest one in seconds.
+    pub async fn circuit_metrics(&self) -> Result<CircuitMetrics> {
+        let client_guard = self.client.lock().await;
+        let _client = client_guard.as_ref().ok_or(Error::NotConnected)?;
+
+        // TODO: arti currently exposes no stable API to list open circuits.
+        // For now we return zero values.
+        Ok(CircuitMetrics {
+            count: 0,
+            oldest_age: 0,
         })
     }
 }

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -75,6 +75,10 @@ fn mock_state() -> AppState<MockTorClient> {
         log_lock: Arc::new(Mutex::new(())),
         retry_counter: Arc::new(Mutex::new(0)),
         max_log_lines: 1000,
+        memory_usage: Arc::new(Mutex::new(0)),
+        circuit_count: Arc::new(Mutex::new(0)),
+        max_memory_mb: 1024,
+        max_circuits: 20,
     }
 }
 


### PR DESCRIPTION
## Summary
- add placeholder circuit metric gathering to `TorManager`
- track memory and circuit counts in `AppState`
- expose new `get_metrics` command
- wire command in app
- add `sysinfo` dependency

## Testing
- `cargo test --all --quiet` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a2c7e6248333adb73f1d13dcda46