### PR TITLE
Document backoff and retry features

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for guidelines on code style, t
 ## 🐞 Troubleshooting
 
 Common issues and log analysis tips are documented in [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).
+The connection code already implements backoff with a maximum total time and logs each retry via `AppState.retry_counter`.
 
 ## 📜 License
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -30,6 +30,10 @@
 - Parallel isolated circuits per domain via updated `get_isolated_circuit`
 - Bridge selection list in the settings modal
 
+## [2.2.2] - 2025-07-05
+### Added
+- Documented that connection retries and timeouts are already implemented.
+
 ## [2.0.0] - 2025-06-15
 ### Initial Release
 - Rewritten architecture with Rust backend and Svelte frontend

--- a/docs/NextSteps.md
+++ b/docs/NextSteps.md
@@ -49,7 +49,7 @@
   - No automatic reconnection logic
   - Limited error recovery
 - **Proposed Enhancements**:
-  - Implement exponential backoff for reconnections
+  - Exponential backoff for reconnections **implemented** via `connect_with_backoff`
   - Add circuit health monitoring
   - Implement fallback bridges
 

--- a/docs/TODO123.md
+++ b/docs/TODO123.md
@@ -16,3 +16,5 @@
 
 ## Completed Features
 - Multiple simultaneous circuits per domain
+- Connection retries use exponential backoff with a maximum total time.
+- Each failed attempt increments `AppState.retry_counter` and is logged.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -16,4 +16,5 @@ This guide lists common problems encountered during development and how to analy
 - If the UI fails to load, open the browser developer tools (`Ctrl+Shift+I`) to inspect console logs and network activity.
 - Failed connection attempts are recorded with `WARN` level. The retry counter resets when a new connection starts.
 - If `Error::Timeout` occurs, the Tor bootstrap exceeded the allowed time. Check your network or increase the limit.
+- The function `connect_with_backoff` enforces a maximum overall connection time and logs each retry.
 


### PR DESCRIPTION
## Summary
- highlight implemented connection backoff and retry tracking
- mention exponential backoff in roadmap as completed
- clarify connection timeout and retry logging in troubleshooting

## Testing
- `pnpm run check`
- `cargo check` *(fails: `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c1dcbf1883338e10de1fe5071780