### PR TITLE
Document circuit metrics limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for guidelines on code style, t
 
 Common issues and log analysis tips are documented in [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).
 The connection code already implements backoff with a maximum total time and logs each retry via `AppState.retry_counter`.
+## ⚠ Known Limitations
+See [docs/Limitations.md](docs/Limitations.md) for features that are currently impossible to implement, including per-circuit metrics.
 
 ## 📜 License
 

--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -1,0 +1,9 @@
+# Known Limitations
+
+## Circuit Metrics
+
+It is currently impossible to report the number of active circuits or their ages.
+The `arti-client` and `tor-circmgr` crates do not expose any API for listing
+active circuits, so `TorManager::circuit_metrics` returns zeros as a placeholder.
+Until upstream libraries provide this functionality, accurate circuit metrics
+cannot be collected.

--- a/docs/NextSteps.md
+++ b/docs/NextSteps.md
@@ -58,6 +58,7 @@
   - Implement circuit isolation by domain
   - Add support for custom exit policies
   - Improve circuit build timeout handling
+  - Circuit metrics (count and age) cannot be collected: arti-client does not expose circuit listings.
 
 #### 2.1.3 GeoIP Handling
 - Country codes are now resolved using the embedded Tor GeoIP database.

--- a/docs/TODO123.md
+++ b/docs/TODO123.md
@@ -18,3 +18,6 @@
 - Multiple simultaneous circuits per domain
 - Connection retries use exponential backoff with a maximum total time.
 - Each failed attempt increments `AppState.retry_counter` and is logged.
+
+## Limitations
+- Circuit metrics (active circuit count and age) cannot be implemented because the arti-client library does not expose a way to list circuits.


### PR DESCRIPTION
## Summary
- add docs/Limitations.md describing why circuit metrics can't be implemented
- mention the missing circuit metrics API in NextSteps.md and TODO123.md
- link to the limitation doc from README

## Testing
- `cargo test` *(fails: the build was interrupted due to long compile time)*

------
https://chatgpt.com/codex/tasks/task_e_6863ca7fc2748333b8b79994ceb64fe0