### PR TITLE
Add backend ping command and integrate in UI

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3"
 once_cell = "1"
 tauri = { version = "1.6.0", features = [] }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
+regex = "1"
 arti-client = { version = "0.31.0", features = ["tokio", "rpc", "full", "experimental-api", "geoip"] }
 tor-rtcompat = { version = "0.31.0" }
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,7 +44,8 @@ pub fn run() {
             commands::get_metrics,
             commands::get_logs,
             commands::clear_logs,
-            commands::get_log_file_path
+            commands::get_log_file_path,
+            commands::ping_host
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/components/StatusCard.svelte
+++ b/src/lib/components/StatusCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Activity, Zap } from "lucide-svelte";
+  import { invoke } from "@tauri-apps/api/tauri";
 
   export let status;
   export let totalTrafficMB = 0;
@@ -17,15 +18,16 @@
     return `${mb} MB`;
   }
 
-  // Ping-Funktion - 5 Pings an google.com
+  // Ping function - execute backend ping command
   async function performPing() {
     if (isPinging) return;
     isPinging = true;
     try {
-      // Hier würde die echte Ping-Implementierung stehen
-      // Simuliere 5 Pings und berechne Durchschnitt
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      pingMs = Math.floor(Math.random() * 100) + 20; // Simulierter Ping 20-120ms
+      const result: number = await invoke("ping_host", {
+        host: "google.com",
+        count: 5
+      });
+      pingMs = result;
     } catch (error) {
       console.error("Ping failed:", error);
       pingMs = -1;


### PR DESCRIPTION
## Summary
- add `ping_host` Tauri command to execute system `ping`
- expose `ping_host` from the backend
- use `ping_host` from `StatusCard` for real latency
- add regex dependency

## Testing
- `cargo test --all-targets --verbose` *(fails: glib-2.0 missing)*
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643845ec98833390d2d0c576bef5e8