### PR TITLE
Add rate limiting for commands

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -18,3 +18,8 @@ This guide lists common problems encountered during development and how to analy
 - If `Error::Timeout` occurs, the Tor bootstrap exceeded the allowed time. Check your network or increase the limit.
 - The function `connect_with_backoff` enforces a maximum overall connection time and logs each retry.
 
+## Rate Limits
+
+- Connection attempts are limited to **5 per minute**. Exceeding this limit returns a `RateLimited` error.
+- Retrieving logs via `get_logs` is limited to **20 requests per minute**.
+

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ rustls = "0.23"
 rustls-pemfile = "2"
 anyhow = "1"
 sysinfo = "0.30"
+governor = "0.10.0"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -35,6 +35,9 @@ pub enum Error {
 
     #[error("Identity change failed: {0}")]
     Identity(String),
+
+    #[error("Rate limit exceeded for {0}")]
+    RateLimited(String),
 }
 
 impl From<arti_client::Error> for Error {


### PR DESCRIPTION
## Summary
- use governor crate to limit connection attempts and log retrievals
- track command invocations over a time window
- surface `RateLimited` error to the frontend
- document default rate limits

## Testing
- `pnpm run check`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686440663ce48333b7ae71544f681a18