### PR TITLE
Align docs and CI on bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'pnpm'
-      - run: pnpm install
-      - run: pnpm run check
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run check

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ cd Torwell
 # Install the Rust toolchain (provides `rustup` and `cargo`)
 curl https://sh.rustup.rs -sSf | sh
 
-# Install dependencies
-bun install  # Install Node.js dependencies
+# Install dependencies (using Bun as the package manager)
+bun install
 
 # Start development server
 bun tauri dev


### PR DESCRIPTION
## Summary
- mention bun package manager in README
- use bun instead of pnpm in CI workflow

## Testing
- `bun install`
- `bun run check`
- `cargo test` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68662fb7edb0833398a6c7445535485a