### PR TITLE
Add initial Vitest setup and ActionCard test

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,19 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "test": "vitest"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.1",
     "@sveltejs/kit": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@tauri-apps/cli": "1.6.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/svelte": "^5.2.8",
     "@types/node": "^20.10.0",
     "autoprefixer": "^10.4.16",
+    "jsdom": "^26.1.0",
     "postcss": "^8.4.32",
     "prettier": "^3.6.2",
     "prettier-plugin-svelte": "^3.4.0",
@@ -27,7 +31,8 @@
     "svelte-check": "^3.6.0",
     "tailwindcss": "^3.3.6",
     "typescript": "^5.0.0",
-    "vite": "^5.0.3"
+    "vite": "^5.0.3",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@tauri-apps/api": "^1.5.0",

--- a/src/__tests__/ActionCard.spec.ts
+++ b/src/__tests__/ActionCard.spec.ts
@@ -1,0 +1,34 @@
+import { vi, describe, it, expect } from 'vitest';
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock('@tauri-apps/api/tauri', () => ({ invoke: vi.fn() }));
+import { render, fireEvent } from '@testing-library/svelte';
+import ActionCard from '../lib/components/ActionCard.svelte';
+
+// Reset store between tests by importing after test to ensure fresh instance
+import { torStore } from '../lib/stores/torStore';
+
+describe('ActionCard', () => {
+  it('renders Connect button when stopped', () => {
+    torStore.set({
+      status: 'DISCONNECTED',
+      bootstrapProgress: 0,
+      bootstrapMessage: '',
+      errorMessage: null,
+      retryCount: 0,
+      retryDelay: 0,
+      memoryUsageMB: 0,
+      circuitCount: 0,
+    });
+
+    const { getByRole } = render(ActionCard);
+    expect(getByRole('button', { name: /connect to tor/i })).toBeInTheDocument();
+  });
+
+  it('dispatches openLogs event when Logs button is clicked', async () => {
+    const { getByRole, component } = render(ActionCard);
+    const handler = vi.fn();
+    component.$on('openLogs', handler);
+    await fireEvent.click(getByRole('button', { name: /open logs/i }));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "types": ["vitest/globals"]
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig(({ mode }) => {
   return {
@@ -24,6 +24,11 @@ export default defineConfig(({ mode }) => {
       minify: !process.env.TAURI_DEBUG ? 'esbuild' : false,
       // produce sourcemaps for debug builds
       sourcemap: !!process.env.TAURI_DEBUG,
+    },
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      setupFiles: './src/setupTests.ts',
     },
   };
 });


### PR DESCRIPTION
## Summary
- add Vitest and Testing Library dependencies
- enable Vitest config in `vite.config.js`
- expose `pnpm test` script
- configure TypeScript for Vitest globals
- add setup file for jest-dom matchers
- create an ActionCard unit test

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68662fba101083338c695915684eebb3