### PR TITLE
Update cert_url with working download

### DIFF
--- a/src-tauri/certs/cert_config.json
+++ b/src-tauri/certs/cert_config.json
@@ -1,4 +1,4 @@
 {
   "cert_path": "src-tauri/certs/server.pem",
-  "cert_url": "https://example.com/certs/server.pem"
+  "cert_url": "https://raw.githubusercontent.com/Christopher-Schulze/Torwell/main/src-tauri/certs/server.pem"
 }


### PR DESCRIPTION
## Summary
- set `cert_url` in `cert_config.json` to a valid URL from the repository

## Testing
- `pnpm run check`
- `cargo check` *(fails: gdk-sys build script can't find `gdk-3.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68662fb57aec8333a3724e97073a3446