### PR TITLE
Add ActionCard tests and test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.1",

--- a/src/__tests__/ActionCard.spec.ts
+++ b/src/__tests__/ActionCard.spec.ts
@@ -1,8 +1,9 @@
 import { vi, describe, it, expect } from 'vitest';
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
-vi.mock('@tauri-apps/api/tauri', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api', () => ({ invoke: vi.fn() }));
 import { render, fireEvent } from '@testing-library/svelte';
 import ActionCard from '../lib/components/ActionCard.svelte';
+import { invoke } from '@tauri-apps/api';
 
 // Reset store between tests by importing after test to ensure fresh instance
 import { torStore } from '../lib/stores/torStore';
@@ -30,5 +31,22 @@ describe('ActionCard', () => {
     component.$on('openLogs', handler);
     await fireEvent.click(getByRole('button', { name: /open logs/i }));
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls disconnect when Disconnect button clicked', async () => {
+    torStore.set({
+      status: 'CONNECTED',
+      bootstrapProgress: 0,
+      bootstrapMessage: '',
+      errorMessage: null,
+      retryCount: 0,
+      retryDelay: 0,
+      memoryUsageMB: 0,
+      circuitCount: 0,
+    });
+
+    const { getByRole } = render(ActionCard);
+    await fireEvent.click(getByRole('button', { name: /disconnect from tor/i }));
+    expect(invoke).toHaveBeenCalledWith('disconnect');
   });
 });


### PR DESCRIPTION
## Summary
- add basic test for ActionCard disconnect button and convert to vitest run script

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68665ea64dc08333867b1851b945af81