### PR TITLE
Add note for certificate URL configuration

### DIFF
--- a/src-tauri/certs/cert_config.json
+++ b/src-tauri/certs/cert_config.json
@@ -1,4 +1,5 @@
 {
   "cert_path": "src-tauri/certs/server.pem",
-  "cert_url": "https://raw.githubusercontent.com/Christopher-Schulze/Torwell/main/src-tauri/certs/server.pem"
+  "cert_url": "https://raw.githubusercontent.com/Christopher-Schulze/Torwell/main/src-tauri/certs/server.pem",
+  "note": "Replace cert_url with your own certificate URL"
 }


### PR DESCRIPTION
## Summary
- update `cert_config.json` to include a hint about providing your own certificate URL

## Testing
- `npm test`
- `cargo test` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68665ea2d8dc8333adc9ff5bae825384