### PR TITLE
Use ProjectDirs for persistent log path

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ rustls-pemfile = "2"
 anyhow = "1"
 sysinfo = "0.30"
 governor = "0.10.0"
+directories = "6.0"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3,6 +3,7 @@ use crate::secure_http::SecureHttpClient;
 use crate::tor_manager::{TorClientBehavior, TorManager};
 use arti_client::TorClient;
 use chrono::Utc;
+use directories::ProjectDirs;
 use log::Level;
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -69,12 +70,21 @@ pub struct AppState<C: TorClientBehavior = TorClient<PreferredRuntime>> {
 
 impl<C: TorClientBehavior> Default for AppState<C> {
     fn default() -> Self {
-        let log_file = std::env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join("torwell.log");
-        if let Some(parent) = log_file.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
+        let log_file = if let Some(proj) = ProjectDirs::from("", "", "torwell84") {
+            let path = proj.data_dir().join("torwell.log");
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            path
+        } else {
+            let path = std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join("torwell.log");
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            path
+        };
 
         let cfg = AppConfig::load(DEFAULT_CONFIG_PATH);
         let mut max_log_lines = cfg.max_log_lines;
@@ -109,12 +119,21 @@ impl<C: TorClientBehavior> Default for AppState<C> {
 
 impl<C: TorClientBehavior> AppState<C> {
     pub fn new(http_client: Arc<SecureHttpClient>) -> Self {
-        let log_file = std::env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join("torwell.log");
-        if let Some(parent) = log_file.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
+        let log_file = if let Some(proj) = ProjectDirs::from("", "", "torwell84") {
+            let path = proj.data_dir().join("torwell.log");
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            path
+        } else {
+            let path = std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join("torwell.log");
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            path
+        };
 
         let cfg = AppConfig::load(DEFAULT_CONFIG_PATH);
         let mut max_log_lines = cfg.max_log_lines;

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -195,7 +195,7 @@ async fn command_log_retrieval() {
     let logs = commands::get_logs(state).await.unwrap();
     assert!(logs.is_empty());
     let path = commands::get_log_file_path(state).await.unwrap();
-    assert!(path.ends_with("test.log"));
+    assert_eq!(path, state.log_file_path());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add the `directories` crate
- compute log file location using `ProjectDirs::data_dir`
- update log path expectation in log retrieval test

## Testing
- `cargo test --quiet` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686683bd3b888333a9dbccc491bd853b