### PR TITLE
Add cross-platform build targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,26 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: bun run check
+
+  bundle:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run tauri build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bundle-${{ matrix.os }}
+          path: src-tauri/target/release/bundle

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,13 @@
     "bundle": {
         "identifier": "com.torwell84.v2.app",
         "active": true,
-        "targets": ["app"],
+        "targets": [
+            "app",
+            "dmg",
+            "msi",
+            "appimage",
+            "deb"
+        ],
         "icon": [
             "icons/32x32.png",
             "icons/128x128.png",


### PR DESCRIPTION
## Summary
- build bundles for Linux and Windows via GitHub Actions
- configure Tauri to generate cross-platform bundles

## Testing
- `bun run tauri build` *(fails: missing system library `glib-2.0`)*
- `bun run check` *(fails: svelte-check errors)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: missing `glib-2.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68669d05ca288333a2c7688e0084848f