### PR TITLE
Add security audit plan and findings

### DIFF
--- a/docs/SecurityAuditPlan.md
+++ b/docs/SecurityAuditPlan.md
@@ -1,0 +1,41 @@
+# Security Audit Plan
+
+This document outlines the steps for a code audit based on the "Security Audit" section of `docs/NextSteps.md`.
+
+## Scope
+According to `NextSteps.md`, the external review should include:
+- Cryptography implementation
+- Network handling
+- Data storage
+- Process isolation
+
+Penetration testing should cover:
+- Network security
+- Application security
+- System security
+- Privacy protections
+
+## Methodology
+1. **Code Review**
+   - Examine `src-tauri` for correct usage of TLS and certificate pinning.
+   - Review session management in `src-tauri/src/session.rs` and `state.rs`.
+   - Inspect front‑end code in `src/` for secure IPC calls and proper data handling.
+   - Run `cargo audit` and `npm audit` / `bun audit` for dependency checks.
+2. **Static Analysis**
+   - Use tools like `clippy` for Rust and `svelte-check` for Svelte components.
+3. **Penetration Testing**
+   - Simulate network attacks against the application APIs.
+   - Validate sandboxing and process isolation features.
+4. **Reporting**
+   - Document all findings in `docs/SecurityFindings.md` with severity and recommended fixes.
+
+## Timeline
+- Preparation: 1 week
+- Code analysis: 2 weeks
+- Penetration tests: 1 week
+- Reporting: 1 week
+
+## Responsibilities
+- Lead Auditor: coordinates the review
+- Developers: provide code context and implement fixes
+

--- a/docs/SecurityFindings.md
+++ b/docs/SecurityFindings.md
@@ -1,0 +1,24 @@
+# Security Audit Findings
+
+This report summarizes security issues discovered during a brief review of the repository.
+
+## 1. Example Certificate URL
+- **File:** `src-tauri/certs/cert_config.json`
+- **Issue:** `cert_url` defaults to an example domain.
+- **Risk:** Using the placeholder URL may allow an attacker to replace the pinned certificate if the domain is not updated.
+- **Recommendation:** Update `cert_url` to a trusted location before deployment.
+
+## 2. Unencrypted Local Storage
+- **File:** `src/lib/database.ts`
+- **Issue:** Application settings are stored unencrypted in IndexedDB.
+- **Risk:** Local attackers could read configuration values such as bridge lists or exit-country preferences.
+- **Recommendation:** Consider encrypting sensitive fields or protecting access with OS-level permissions.
+
+## 3. External `ping` Command
+- **File:** `src-tauri/src/commands.rs`
+- **Issue:** The `ping_host` command spawns the system `ping` binary.
+- **Risk:** Although arguments are passed directly, excessive calls could be abused for resource consumption.
+- **Recommendation:** Validate input and limit invocations or implement an internal ICMP check instead of spawning a process.
+
+No critical vulnerabilities were found, but the above issues should be addressed to improve the overall security posture.
+


### PR DESCRIPTION
## Summary
- document a security audit plan based on `NextSteps.md`
- record findings from a quick review

## Testing
- `bun run test` *(fails: ParseError in TorChain.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_6866edca899c83339923f3385a1cbdca