### PR TITLE
Implement metrics emitter and log rotation

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -11,7 +11,7 @@ This guide lists common problems encountered during development and how to analy
 ## Debugging & Log Analysis
 
 - Start the app in development mode with `bun tauri dev` to view live output.
-- The backend writes logs to a persistent file named `torwell.log` in the project directory. Older entries are trimmed once the file exceeds the configured line limit.
+- The backend writes logs to a persistent file named `torwell.log` in the project directory. When the file exceeds the configured line limit it is rotated and the previous log is moved into an `archive` folder.
 - Each line of this file is a JSON object with `level`, `timestamp` and `message` fields.
 - If the UI fails to load, open the browser developer tools (`Ctrl+Shift+I`) to inspect console logs and network activity.
 - Failed connection attempts are recorded with `WARN` level. The retry counter resets when a new connection starts.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,8 @@ pub fn run() {
                         .build(),
                 )?;
             }
+            let state = app.state::<AppState>();
+            state.clone().start_metrics_task(app.handle());
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -106,7 +106,7 @@
       {totalTrafficMB}
       memoryMB={$torStore.memoryUsageMB}
       circuitCount={$torStore.circuitCount}
-      pingMs={undefined}
+      pingMs={$torStore.pingMs}
     />
 
     <TorChain


### PR DESCRIPTION
## Summary
- archive log files in `state.rs` when exceeding limit
- capture network latency and memory metrics periodically
- emit `metrics-update` events to the frontend
- adapt Svelte store and page to use new metrics
- document log rotation behaviour

## Testing
- `cargo test` *(fails: system library `glib-2.0` not found)*
- `bun test` *(fails: Cannot find module '@testing-library/svelte')*

------
https://chatgpt.com/codex/tasks/task_e_6866edc945d08333aa076f19d1158e9e