### PR TITLE
Enable tray and updater

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 thiserror = "1.0"
 futures = "0.3"
 once_cell = "1"
-tauri = { version = "1.6.0", features = [] }
+tauri = { version = "1.6.0", features = ["system-tray", "updater"] }
 tauri-plugin-log = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 regex = "1"
 arti-client = { version = "0.31.0", features = ["tokio", "rpc", "full", "experimental-api", "geoip"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod tor_manager;
 use secure_http::SecureHttpClient;
 use state::AppState;
 use std::time::Duration;
+use tauri::{CustomMenuItem, SystemTray, SystemTrayEvent, SystemTrayMenu};
 
 pub fn run() {
     let http_client = tauri::async_runtime::block_on(async {
@@ -21,7 +22,26 @@ pub fn run() {
     });
     let app_state = AppState::new(http_client);
 
+    let quit = CustomMenuItem::new("quit", "Quit");
+    let show = CustomMenuItem::new("show", "Show");
+    let tray_menu = SystemTrayMenu::new().add_item(show.clone()).add_item(quit.clone());
+    let tray = SystemTray::new().with_menu(tray_menu);
+
     tauri::Builder::default()
+        .system_tray(tray)
+        .on_system_tray_event(|app, event| match event {
+            SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
+                "quit" => std::process::exit(0),
+                "show" => {
+                    if let Some(window) = app.get_window("main") {
+                        let _ = window.show();
+                        let _ = window.set_focus();
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        })
         .manage(app_state)
         .setup(|app| {
             if cfg!(debug_assertions) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,6 +41,16 @@
         "maximizable": false,
         "minimizable": true
       }
-    ]
+    ],
+    "systemTray": {
+      "iconPath": "icons/icon.png",
+      "iconAsTemplate": true
+    },
+    "updater": {
+      "active": true,
+      "endpoints": [
+        "https://example.com/updates/{platform}/{arch}"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- enable `system-tray` and `updater` features for Tauri
- create a tray menu with Show and Quit options
- configure the updater endpoint and tray icon in `tauri.conf.json`

## Testing
- `cargo test --quiet` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866edc7f920833380a962ca44fc7e59