### PR TITLE
Update certificate config and docs

### DIFF
--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -89,3 +89,17 @@ Serverzertifikate alle 90 Tage erneuert. `SecureHttpClient` ruft das
 aktuelle PEM automatisch vom konfigurierten Endpunkt ab und ersetzt die
 lokale Datei. So bleibt der Zertifikatspool stets aktuell, ohne dass ein
 Neustart der Anwendung erforderlich ist.
+
+### Rotation Workflow
+
+1. Lege das neue Zertifikat auf dem Produktionsserver unter
+   `https://certs.torwell.com/server.pem` ab.
+2. Beim Start liest `SecureHttpClient` `cert_config.json` ein und
+   verwendet `cert_url`, sofern keine Umgebungsvariable gesetzt ist.
+   Wird `TORWELL_CERT_URL` definiert, hat dieser Wert Vorrang.
+3. Der Client lädt das neue PEM herunter und ersetzt die Datei unter
+   `cert_path`. Anschließend werden die Zertifikate im laufenden Prozess
+   neu geladen.
+4. Überprüfe die Logdatei auf Meldungen wie
+   `certificate update failed` oder erfolgreiche Aktualisierungen, um
+   sicherzustellen, dass der Wechsel stattgefunden hat.

--- a/src-tauri/certs/cert_config.json
+++ b/src-tauri/certs/cert_config.json
@@ -1,5 +1,5 @@
 {
   "cert_path": "src-tauri/certs/server.pem",
-  "cert_url": "https://raw.githubusercontent.com/Christopher-Schulze/Torwell/main/src-tauri/certs/server.pem",
-  "note": "Replace cert_url with your own certificate URL"
+  "cert_url": "https://certs.torwell.com/server.pem",
+  "note": "Production certificate update endpoint"
 }


### PR DESCRIPTION
## Summary
- point `cert_config.json` at the production certificate server
- clarify rotation workflow in `CertificateManagement.md`
- note that `TORWELL_CERT_URL` overrides the config file

## Testing
- `bun run test` *(fails: ParseError in TorChain.svelte)*
- `cargo test` in `src-tauri` *(fails: missing `glib-2.0` system library)*

------
https://chatgpt.com/codex/tasks/task_e_6866f9cb2a74833399a5077898f6860a