### PR TITLE
Add session tokens and secure commands

### DIFF
--- a/docs/SecurityAuditPlan.md
+++ b/docs/SecurityAuditPlan.md
@@ -39,3 +39,11 @@ Penetration testing should cover:
 - Lead Auditor: coordinates the review
 - Developers: provide code context and implement fixes
 
+## Session Tokens
+
+The backend issues a random session token on startup. High‑risk commands such as
+log retrieval and network diagnostics require this token. The audit should
+verify that tokens are generated securely, expire after the configured TTL and
+that the front‑end supplies the token via the `token` argument in `tauri::invoke`
+calls.
+

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -38,6 +38,9 @@ pub enum Error {
 
     #[error("Rate limit exceeded for {0}")]
     RateLimited(String),
+
+    #[error("Invalid session token")]
+    InvalidToken,
 }
 
 impl From<arti_client::Error> for Error {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,7 +69,8 @@ pub fn run() {
             commands::clear_logs,
             commands::get_log_file_path,
             commands::set_log_limit,
-            commands::ping_host
+            commands::ping_host,
+            commands::request_token
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/__tests__/StatusCard.spec.ts
+++ b/src/__tests__/StatusCard.spec.ts
@@ -34,7 +34,11 @@ describe('StatusCard', () => {
 
     await fireEvent.click(getByRole('button', { name: /run ping test/i }));
 
-    expect(invoke).toHaveBeenCalledWith('ping_host', { host: 'google.com', count: 5 });
+    expect(invoke).toHaveBeenNthCalledWith(2, 'ping_host', {
+      token: 42,
+      host: 'google.com',
+      count: 5
+    });
     await findByText('42 ms');
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,14 @@
+import { invoke as tauriInvoke } from '@tauri-apps/api/tauri';
+
+let token: string | null = null;
+
+export async function ensureToken(): Promise<string> {
+  if (token) return token;
+  token = await tauriInvoke<string>('request_token');
+  return token;
+}
+
+export async function invoke(cmd: string, args: Record<string, any> = {}) {
+  const t = await ensureToken();
+  return tauriInvoke(cmd, { token: t, ...args });
+}

--- a/src/lib/components/LogsModal.svelte
+++ b/src/lib/components/LogsModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
         import { X, Download, Copy, Trash2, FolderOpen } from 'lucide-svelte';
         import { createEventDispatcher, onMount, tick } from 'svelte';
-        import { invoke } from '@tauri-apps/api';
+        import { invoke } from '$lib/api';
         import { open } from '@tauri-apps/api/shell';
 
 	export let show = false;

--- a/src/lib/components/StatusCard.svelte
+++ b/src/lib/components/StatusCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Activity, Zap } from "lucide-svelte";
-  import { invoke } from "@tauri-apps/api/tauri";
+  import { invoke } from "$lib/api";
 
   export let status;
   export let totalTrafficMB = 0;


### PR DESCRIPTION
## Summary
- issue a startup token in `SessionManager`
- add `request_token` command and require tokens for log/ping functions
- expose a small front-end API for invoking secured commands
- update StatusCard and LogsModal to use the new API
- document token usage in SecurityAuditPlan
- adjust StatusCard test for token argument

## Testing
- `npx vitest run` *(fails: vitest not installed)*
- `cargo test --no-run` *(fails: network restrictions prevent fetching crates)*

------
https://chatgpt.com/codex/tasks/task_e_6866f9d2da908333a23d2f26ca1c03d9