### PR TITLE
Add ping_host validation

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -55,6 +55,9 @@ const API_LIMIT: u32 = 60;
 static API_LIMITER: Lazy<RateLimiter<NotKeyed, InMemoryState, DefaultClock>> =
     Lazy::new(|| RateLimiter::direct(Quota::per_minute(NonZeroU32::new(API_LIMIT).unwrap())));
 
+const MAX_PING_COUNT: u8 = 10;
+static HOST_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[A-Za-z0-9.-]+$").unwrap());
+
 fn check_api_rate() -> Result<()> {
     API_LIMITER
         .check()
@@ -326,7 +329,10 @@ pub async fn ping_host(host: Option<String>, count: Option<u8>) -> Result<u64> {
     track_call("ping_host").await;
     check_api_rate()?;
     let host = host.unwrap_or_else(|| "google.com".to_string());
-    let count = count.unwrap_or(5).to_string();
+    if !HOST_RE.is_match(&host) {
+        return Err(Error::Io("invalid host".into()));
+    }
+    let count = count.unwrap_or(5).min(MAX_PING_COUNT).to_string();
     let mut cmd = if cfg!(target_os = "windows") {
         let mut c = Command::new("ping");
         c.arg("-n").arg(&count).arg(&host);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,7 +24,9 @@ pub fn run() {
 
     let quit = CustomMenuItem::new("quit", "Quit");
     let show = CustomMenuItem::new("show", "Show");
-    let tray_menu = SystemTrayMenu::new().add_item(show.clone()).add_item(quit.clone());
+    let tray_menu = SystemTrayMenu::new()
+        .add_item(show.clone())
+        .add_item(quit.clone());
     let tray = SystemTray::new().with_menu(tray_menu);
 
     tauri::Builder::default()

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -286,3 +286,16 @@ async fn command_clear_bridges() {
     commands::set_bridges(state, Vec::new()).await.unwrap();
     assert!(state.tor_manager.get_bridges().await.is_empty());
 }
+
+#[tokio::test]
+async fn ping_host_invalid_hostname() {
+    let res = commands::ping_host(Some("bad host$".into()), Some(1)).await;
+    assert!(matches!(res, Err(Error::Io(_))));
+}
+
+#[tokio::test]
+async fn ping_host_count_capped() {
+    // should succeed using localhost even when count exceeds limit
+    let res = commands::ping_host(Some("127.0.0.1".into()), Some(100)).await;
+    assert!(res.is_ok());
+}


### PR DESCRIPTION
## Summary
- validate ping targets in `ping_host`
- limit allowable ping count
- add tests covering invalid hostname and count

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: The updater `pubkey` configuration is required)*

------
https://chatgpt.com/codex/tasks/task_e_6866f9d19f508333a688f4cc1c81d8a0