### PR TITLE
Implement encryption for settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@testing-library/svelte": "^5.2.8",
         "@types/node": "^20.10.0",
         "autoprefixer": "^10.4.16",
+        "fake-indexeddb": "^6.0.1",
         "jsdom": "^26.1.0",
         "postcss": "^8.4.32",
         "prettier": "^3.6.2",
@@ -2383,6 +2384,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+      "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-glob": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@testing-library/svelte": "^5.2.8",
     "@types/node": "^20.10.0",
     "autoprefixer": "^10.4.16",
+    "fake-indexeddb": "^6.0.1",
     "jsdom": "^26.1.0",
     "postcss": "^8.4.32",
     "prettier": "^3.6.2",

--- a/src/__tests__/database.spec.ts
+++ b/src/__tests__/database.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import Dexie from 'dexie';
+
+import { db } from '../lib/database';
+
+function openRaw() {
+  const raw = new Dexie('Torwell84DatabaseV2');
+  raw.version(1).stores({
+    settings: '++id, workerList, torrcConfig, exitCountry, bridges, maxLogLines',
+  });
+  return raw.open().then(() => raw);
+}
+
+describe('database encryption', () => {
+  beforeEach(async () => {
+    await db.delete();
+    await db.open();
+  });
+
+  it('encrypts sensitive fields on write and decrypts on read', async () => {
+    await db.settings.put({
+      id: 1,
+      workerList: [],
+      torrcConfig: '',
+      exitCountry: 'US',
+      bridges: ['b1'],
+      maxLogLines: 10,
+    });
+
+    const stored = await db.settings.get(1);
+    expect(stored?.exitCountry).toBe('US');
+    expect(stored?.bridges).toEqual(['b1']);
+
+    const raw = await openRaw();
+    const rawData = await raw.table('settings').get(1);
+    expect(rawData.exitCountry).not.toBe('US');
+    expect(rawData.bridges[0]).not.toBe('b1');
+
+    await raw.close();
+  });
+});

--- a/src/lib/components/TorChain.svelte
+++ b/src/lib/components/TorChain.svelte
@@ -92,27 +92,37 @@
 							{getCountryFlag(country)} {country}
 						</option>
 					{/each}
-				</select>
-				<div class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-					<svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                </select>
+                                <div class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+                                        <svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                        </svg>
+                                </div>
+                        </div>
+                </div>
+
+                <!-- Middle Node Dropdown -->
+                <div class="flex items-center h-8">
+                        <div class="relative w-full h-8">
+                                <select
                                         class="w-full h-8 bg-black/50 border border-white/20 rounded-lg px-2 py-1 text-xs text-white focus:outline-none focus:border-white/40 hover:bg-black/60 transition-all appearance-none cursor-pointer"
                                         value={middleCountry}
                                         aria-label="Middle node country"
                                         on:change={(e) => handleCountryChange('middle', e)}
                                 >
-					{#each countries as country}
-						<option value={country} class="bg-gray-800 text-xs">
-							{getCountryFlag(country)} {country}
-						</option>
-					{/each}
-				</select>
-				<div class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-					<svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-					</svg>
-				</div>
-			</div>
-		</div>
+                                        {#each countries as country}
+                                                <option value={country} class="bg-gray-800 text-xs">
+                                                        {getCountryFlag(country)} {country}
+                                                </option>
+                                        {/each}
+                                </select>
+                                <div class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+                                        <svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                        </svg>
+                                </div>
+                        </div>
+                </div>
 		
 		<!-- Exit Node Dropdown -->
 		<div class="flex items-center h-8">
@@ -340,4 +350,3 @@
                 </ul>
         </div>
 {/if}
-</div>

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,6 +1,44 @@
 // lib/database.ts
 import Dexie, { type Table } from "dexie";
 
+const SECRET = "torwell-key";
+
+function xor(str: string): string {
+  return Array.from(str)
+    .map((c, i) =>
+      String.fromCharCode(c.charCodeAt(0) ^ SECRET.charCodeAt(i % SECRET.length))
+    )
+    .join("");
+}
+
+function encryptString(value: string): string {
+  return btoa(xor(value));
+}
+
+function decryptString(value: string): string {
+  return xor(atob(value));
+}
+
+function encryptFields(obj: Partial<Settings>): void {
+  if (obj.bridges) {
+    obj.bridges = obj.bridges.map((b) => encryptString(b));
+  }
+  if (obj.exitCountry != null) {
+    obj.exitCountry = encryptString(obj.exitCountry);
+  }
+}
+
+function decryptFields(obj: Settings | undefined): Settings | undefined {
+  if (!obj) return obj;
+  if (obj.bridges) {
+    obj.bridges = obj.bridges.map((b) => decryptString(b));
+  }
+  if (obj.exitCountry != null) {
+    obj.exitCountry = decryptString(obj.exitCountry);
+  }
+  return obj;
+}
+
 export interface Settings {
   id?: number;
   workerList: string[];
@@ -19,6 +57,14 @@ export class AppDatabase extends Dexie {
       settings:
         "++id, workerList, torrcConfig, exitCountry, bridges, maxLogLines", // Primary key and indexed props
     });
+
+    this.settings.hook("creating", (_pk, obj) => {
+      encryptFields(obj);
+    });
+    this.settings.hook("updating", (mods) => {
+      encryptFields(mods as Partial<Settings>);
+    });
+    this.settings.hook("reading", (obj) => decryptFields(obj));
   }
 }
 


### PR DESCRIPTION
## Summary
- encrypt `bridges` and `exitCountry` when writing to IndexedDB
- decrypt these fields on read
- fix `TorChain.svelte` markup and add middle node dropdown
- add fake-indexeddb and unit test for encrypted database operations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866f9d06b6c8333a53154d7dc8f0ee9