### PR TITLE
Implement fallback certificate update

### DIFF
--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -40,13 +40,16 @@ locations during development.
 {
   "cert_path": "src-tauri/certs/server.pem",
   "cert_url": "https://certs.torwell.com/server.pem",
+  "fallback_cert_url": null,
   "min_tls_version": "1.2"
 }
 ```
 
 `cert_path` is where the PEM file is written. `cert_url` specifies the HTTPS
-endpoint used to retrieve updates. `min_tls_version` defines the minimum TLS
-protocol version the client will accept (either `1.2` or `1.3`).
+endpoint used to retrieve updates. If the primary endpoint fails, an optional
+`fallback_cert_url` can provide an alternative location. `min_tls_version`
+defines the minimum TLS protocol version the client will accept (either `1.2`
+or `1.3`).
 
 When calling `SecureHttpClient::init` you can override these values without
 modifying the file:
@@ -56,6 +59,7 @@ let client = SecureHttpClient::init(
     "src-tauri/certs/cert_config.json",
     Some("/tmp/dev.pem".into()),
     Some("https://localhost/dev_cert.pem".into()),
+    None,
     None,
 ).await?;
 ```
@@ -84,7 +88,8 @@ Ab Version 2.2.2 kann der Update-Endpunkt auch per Umgebungsvariable gesetzt wer
 Wird `TORWELL_CERT_URL` definiert, überschreibt dieser Wert die Einstellung aus
 `cert_config.json`, sofern kein Parameter in `SecureHttpClient::init` gesetzt
 wird. Ebenso kann der Dateipfad durch die Umgebungsvariable
-`TORWELL_CERT_PATH` angepasst werden.
+`TORWELL_CERT_PATH` angepasst werden. Für einen alternativen Update-Server kann
+`TORWELL_FALLBACK_CERT_URL` verwendet werden.
 
 ## Geplante Zertifikatsrotation
 

--- a/docs/NextSteps.md
+++ b/docs/NextSteps.md
@@ -11,7 +11,7 @@
   attacks.
 - **Enhancements**:
   1. Document the certificate rotation strategy
-  2. Add fallback mechanisms for certificate updates
+  2. Add fallback mechanisms for certificate updates **implemented**
 
 #### 1.1.2 TLS Configuration Hardening
 - **Current State**: Uses default TLS settings which may include weak ciphers

--- a/src-tauri/certs/cert_config.json
+++ b/src-tauri/certs/cert_config.json
@@ -1,6 +1,7 @@
 {
   "cert_path": "src-tauri/certs/server.pem",
   "cert_url": "https://certs.torwell.com/server.pem",
+  "fallback_cert_url": null,
   "min_tls_version": "1.2",
   "note": "Production certificate update endpoint"
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub fn run() {
             secure_http::DEFAULT_CONFIG_PATH,
             None,
             None,
+            None,
             Some(Duration::from_secs(60 * 60 * 24)),
         )
         .expect("failed to initialize http client")


### PR DESCRIPTION
## Summary
- add optional fallback URL to `SecureHttpClient` configuration
- load `TORWELL_FALLBACK_CERT_URL` environment variable
- attempt certificate updates from multiple URLs and schedule periodic checks
- update certificate configuration example and documentation
- note feature as implemented in roadmap
- extend unit tests to cover fallback logic

## Testing
- `cargo test --quiet` *(fails: glib-2.0 development files missing)*
- `npm test --silent` *(fails: vitest not found / missing setup)*

------
https://chatgpt.com/codex/tasks/task_e_686785d513ac8333b401b88fda887039