### PR TITLE
Add TorChain tests

### DIFF
--- a/src/__tests__/TorChain.spec.ts
+++ b/src/__tests__/TorChain.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+
+// Mock tauri event listener so store initialization doesn't fail
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+// Provide a minimal mock for the uiStore used by TorChain
+const setExitCountry = vi.fn();
+vi.mock('$lib/stores/uiStore', () => {
+  const { writable } = require('svelte/store');
+  const store = writable({ settings: { exitCountry: null } });
+  return {
+    uiStore: {
+      subscribe: store.subscribe,
+      actions: {
+        setExitCountry: (country: string | null) => {
+          setExitCountry(country);
+          store.set({ settings: { exitCountry: country } });
+        },
+      },
+    },
+  };
+});
+
+import TorChain from '../lib/components/TorChain.svelte';
+
+const nodeData = [
+  { nickname: 'entry', ip_address: '1.1.1.1', country: 'DE' },
+  { nickname: 'middle', ip_address: '2.2.2.2', country: 'FR' },
+  { nickname: 'exit', ip_address: '3.3.3.3', country: 'US' },
+];
+
+describe('TorChain', () => {
+  it('renders node card data only when connected', () => {
+    const { queryByText: queryDisconnected } = render(TorChain, {
+      props: { isConnected: false, nodeData },
+    });
+    expect(queryDisconnected('1.1.1.1')).not.toBeInTheDocument();
+
+    const { getByText } = render(TorChain, {
+      props: { isConnected: true, nodeData },
+    });
+    expect(getByText('1.1.1.1')).toBeInTheDocument();
+    expect(getByText('entry')).toBeInTheDocument();
+  });
+
+  it('calls setExitCountry when exit dropdown changes', async () => {
+    const { getByLabelText } = render(TorChain, {
+      props: { isConnected: true, nodeData },
+    });
+
+    const select = getByLabelText('Preferred exit country') as HTMLSelectElement;
+    await fireEvent.change(select, { target: { value: 'US' } });
+
+    expect(setExitCountry).toHaveBeenCalledWith('US');
+  });
+
+  it('displays isolated circuits list', () => {
+    const isolatedCircuits = [
+      {
+        domain: 'example.com',
+        nodes: [
+          { nickname: 'n1', ip_address: '1.1.1.1', country: 'DE' },
+          { nickname: 'n2', ip_address: '2.2.2.2', country: 'FR' },
+        ],
+      },
+    ];
+
+    const { getByText } = render(TorChain, {
+      props: { isConnected: true, nodeData, isolatedCircuits },
+    });
+
+    expect(getByText('Isolated Circuits')).toBeInTheDocument();
+    expect(getByText(/example.com/)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/database.spec.ts
+++ b/src/__tests__/database.spec.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import 'fake-indexeddb/auto';
+import { indexedDB, IDBKeyRange } from 'fake-indexeddb';
 import Dexie from 'dexie';
+
+// Configure Dexie to use the in-memory IndexedDB provided by fake-indexeddb
+Dexie.dependencies.indexedDB = indexedDB as any;
+Dexie.dependencies.IDBKeyRange = IDBKeyRange as any;
 
 import { db } from '../lib/database';
 


### PR DESCRIPTION
## Summary
- add tests for TorChain component
- ensure database tests use fake IndexedDB correctly

## Testing
- `npx vitest run` *(fails: window.__TAURI_IPC__ not a function)*
- `bun run check` *(fails: svelte-check errors)*
- `cargo check` *(failed to build crates)*

------
https://chatgpt.com/codex/tasks/task_e_6867a667bdd8833385849b50f161da0d