### PR TITLE
Document default cert URL and env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,18 @@ installed (`libglib2.0-dev` on Debian/Ubuntu) before running the tests.
 
 ### Updating Certificates
 The pinned certificate location is configured in `src-tauri/certs/cert_config.json`.
-Change the `cert_url` value to your own server or set the environment variables
-`TORWELL_CERT_URL` or `TORWELL_CERT_PATH` to override the URL and local path at runtime. The minimum TLS version can also
-be configured via the `min_tls_version` field ("1.2" or "1.3").
+By default this file points `cert_url` to `https://certs.torwell.com/server.pem` as a
+placeholder. Change the value to your own server or set the environment variables
+`TORWELL_CERT_URL` or `TORWELL_CERT_PATH` to override the URL and local path at runtime.
+The minimum TLS version can also be configured via the `min_tls_version` field
+("1.2" or "1.3").
+
+Example for development:
+
+```bash
+TORWELL_CERT_URL=https://example.org/certs/server.pem \
+TORWELL_CERT_PATH=src-tauri/certs/custom.pem bun tauri dev
+```
 
 ### Runtime Configuration
 You can influence certain backend parameters via environment variables:

--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -91,6 +91,14 @@ wird. Ebenso kann der Dateipfad durch die Umgebungsvariable
 `TORWELL_CERT_PATH` angepasst werden. Für einen alternativen Update-Server kann
 `TORWELL_FALLBACK_CERT_URL` verwendet werden.
 
+Beispiel für eine abweichende Konfiguration im Entwicklungsmodus:
+
+```bash
+export TORWELL_CERT_URL=https://example.org/certs/server.pem
+export TORWELL_CERT_PATH=src-tauri/certs/custom.pem
+bun tauri dev
+```
+
 ## Geplante Zertifikatsrotation
 
 Um eine durchgehende Vertrauenskette sicherzustellen, werden die


### PR DESCRIPTION
## Summary
- mention that cert_config.json points to `certs.torwell.com` by default
- document how to override the update URL via environment variables
- add example commands for `TORWELL_CERT_URL` and `TORWELL_CERT_PATH`

## Testing
- `bun run check` *(fails: svelte-check reports errors)*
- `cargo test` *(fails: missing `glib-2.0` development headers)*

------
https://chatgpt.com/codex/tasks/task_e_6867a664fa648333bb81aecffd74a14a