### PR TITLE
Add macOS bundle artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -68,3 +68,9 @@ jobs:
         with:
           name: linux-appimage
           path: src-tauri/target/release/bundle/appimage/*.AppImage
+      - name: Upload DMG
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg
+          path: src-tauri/target/release/bundle/dmg/*.dmg


### PR DESCRIPTION
## Summary
- build a macOS binary in CI
- upload the `.dmg` bundle

## Testing
- `act --list`
- `cargo test` *(fails: compile dependencies too heavy)*

------
https://chatgpt.com/codex/tasks/task_e_6867a66384088333bd68a5ea1e88ef67