### PR TITLE
Add Windows build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,25 @@ jobs:
       - run: bun install
       - run: bun run check
 
+  windows-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run check
+      - name: Run cargo test
+        working-directory: src-tauri
+        run: cargo test
+
   bundle:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ You can influence certain backend parameters via environment variables:
 - Rust and Cargo (via rustup)
 - System dependencies for Tauri (see [Tauri prerequisites](https://tauri.app/v1/guides/getting-started/prerequisites))
 
+### Windows Build
+On Windows you also need the **Desktop development with C++** workload from the
+Visual Studio Build Tools. After installing it, install Rust with the MSVC
+toolchain and ensure Node.js and Bun are available.
+
+To build locally:
+
+```bash
+bun install
+bun run check
+cd src-tauri && cargo test && cd ..
+bun run tauri build
+```
+
 ## Installation
 
 ### Windows


### PR DESCRIPTION
## Summary
- document how to build on Windows
- run test & lint on Windows in CI

## Testing
- `cargo test --no-run` *(fails: libsoup-2.4 not found)*
- `bun run check` *(fails: 2 errors)

------
https://chatgpt.com/codex/tasks/task_e_6867b9c5db608333b1d2e3a0904889ab