### PR TITLE
Add runtime environment variable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,13 @@ TORWELL_CERT_PATH=src-tauri/certs/custom.pem bun tauri dev
 ### Runtime Configuration
 You can influence certain backend parameters via environment variables:
 
-- `TORWELL_SESSION_TTL` &ndash; lifetime of authentication tokens in seconds (default `3600`).
+- `TORWELL_CERT_URL` – HTTPS endpoint to download the pinned server certificate.
+- `TORWELL_CERT_PATH` – Local path where the certificate is stored.
+- `TORWELL_FALLBACK_CERT_URL` – Optional backup URL for certificate updates.
+- `TORWELL_SESSION_TTL` – Lifetime of authentication tokens in seconds (default `3600`).
+- `TORWELL_MAX_LOG_LINES` – Maximum number of log lines kept in `torwell.log` (default `1000`).
+- `TORWELL_MAX_MEMORY_MB` – Memory usage threshold before warnings (default `1024`).
+- `TORWELL_MAX_CIRCUITS` – Maximum allowed parallel circuits (default `20`).
 
 > The first build will download many Rust crates and may take several minutes.
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -137,5 +137,11 @@ sequenceDiagram
 
 Das Backend akzeptiert verschiedene Umgebungsvariablen zur Laufzeitkonfiguration.
 
-- `TORWELL_SESSION_TTL` – Lebensdauer eines Session-Tokens in Sekunden (Standard `3600`)
+- `TORWELL_CERT_URL` – HTTPS-Endpunkt zum Abrufen des Serverzertifikats.
+- `TORWELL_CERT_PATH` – Lokaler Pfad zum abgelegten Zertifikat.
+- `TORWELL_FALLBACK_CERT_URL` – Optionale Ausweich-URL für Zertifikatsupdates.
+- `TORWELL_SESSION_TTL` – Lebensdauer eines Session-Tokens in Sekunden (Standard `3600`).
+- `TORWELL_MAX_LOG_LINES` – Maximale Anzahl von Logzeilen, die in `torwell.log` aufbewahrt werden (Standard `1000`).
+- `TORWELL_MAX_MEMORY_MB` – Schwellenwert für Speichernutzung, ab dem Warnungen ausgegeben werden (Standard `1024`).
+- `TORWELL_MAX_CIRCUITS` – Maximale Anzahl erlaubter paralleler Tor-Circuits (Standard `20`).
 


### PR DESCRIPTION
## Summary
- document environment variables used by the backend in docs/DOCUMENTATION.md
- reference the variables in README runtime configuration section

## Testing
- `bun run check` *(fails: block-scoped variable used before declaration)*
- `cargo check` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867b9c761388333a35f2bdd95f5f040