### PR TITLE
Improve error propagation

### DIFF
--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -39,6 +39,15 @@ pub enum Error {
     #[error("Rate limit exceeded for {0}")]
     RateLimited(String),
 
+    #[error("connection failed after {attempts} retries: {error}")]
+    RetriesExceeded { attempts: u32, error: String },
+
+    #[error("bridge parsing failed: {0}")]
+    BridgeParse(String),
+
+    #[error("country lookup failed: {0}")]
+    Lookup(String),
+
     #[error("Invalid session token")]
     InvalidToken,
 }

--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -93,7 +93,7 @@ async fn connect_with_backoff_error() {
             |_| {},
         )
         .await;
-    assert!(matches!(res, Err(Error::Bootstrap(_))));
+    assert!(matches!(res, Err(Error::RetriesExceeded { .. })));
 }
 
 #[tokio::test]
@@ -126,6 +126,24 @@ async fn connect_with_backoff_timeout() {
         )
         .await;
     assert!(matches!(res, Err(Error::Timeout)));
+}
+
+#[tokio::test]
+async fn bridge_parse_error() {
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    manager
+        .set_bridges(vec!["bad bridge".into()])
+        .await
+        .unwrap();
+    let res = manager.connect().await;
+    assert!(matches!(res, Err(Error::BridgeParse(_))));
+}
+
+#[tokio::test]
+async fn lookup_country_error() {
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    let res = manager.lookup_country_code("?.?.?.?").await;
+    assert!(matches!(res, Err(Error::Lookup(_))));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add new error variants for retries, bridge parsing and lookup
- use new variants in TorManager
- test new error paths

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(failed: javascriptcoregtk-4.0.pc missing)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(failed: javascriptcoregtk-4.0.pc missing)*
- `bun run check` *(failed: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b9c4f70c8333a14f965848da1bca