### PR TITLE
Add security warning banner

### DIFF
--- a/src/__tests__/SecurityBanner.spec.ts
+++ b/src/__tests__/SecurityBanner.spec.ts
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/svelte';
+import { vi, describe, it, expect } from 'vitest';
+import { tick } from 'svelte';
+
+let warningCallback: (event: any) => void = () => {};
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn((_event: string, cb: any) => {
+    if (_event === 'security-warning') warningCallback = cb;
+  })
+}));
+
+import SecurityBanner from '../lib/components/SecurityBanner.svelte';
+
+describe('SecurityBanner', () => {
+  it('renders message when event emitted', async () => {
+    const { queryByRole, getByRole } = render(SecurityBanner);
+    expect(queryByRole('alert')).toBeNull();
+
+    warningCallback({ payload: 'warning msg' });
+    await tick();
+
+    expect(getByRole('alert')).toHaveTextContent('warning msg');
+  });
+});

--- a/src/lib/components/SecurityBanner.svelte
+++ b/src/lib/components/SecurityBanner.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { torStore } from "$lib/stores/torStore";
+  import { X } from "lucide-svelte";
+
+  function dismiss() {
+    torStore.update((s) => ({ ...s, securityWarning: null }));
+  }
+</script>
+
+{#if $torStore.securityWarning}
+<div class="bg-yellow-900/80 text-yellow-200 p-2 rounded-lg mb-3 flex items-center justify-between" role="alert">
+  <span class="text-sm">{$torStore.securityWarning}</span>
+  <button on:click={dismiss} aria-label="Dismiss warning" class="ml-2">
+    <X size={14} />
+  </button>
+</div>
+{/if}

--- a/src/lib/stores/torStore.ts
+++ b/src/lib/stores/torStore.ts
@@ -15,6 +15,7 @@ export interface TorState {
   bootstrapProgress: number;
   bootstrapMessage: string;
   errorMessage: string | null;
+  securityWarning: string | null;
   retryCount: number;
   retryDelay: number;
   memoryUsageMB: number;
@@ -28,6 +29,7 @@ function createTorStore() {
     bootstrapProgress: 0,
     bootstrapMessage: "",
     errorMessage: null,
+    securityWarning: null,
     retryCount: 0,
     retryDelay: 0,
     memoryUsageMB: 0,
@@ -45,6 +47,10 @@ function createTorStore() {
       circuitCount: event.payload.circuit_count,
       pingMs: event.payload.latency_ms,
     }));
+  });
+
+  listen<string>("security-warning", (event) => {
+    update((state) => ({ ...state, securityWarning: event.payload }));
   });
 
   // Listen for status updates from the Rust backend

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import TorChain from "$lib/components/TorChain.svelte";
   import ActionCard from "$lib/components/ActionCard.svelte";
   import IdlePanel from "$lib/components/IdlePanel.svelte";
+  import SecurityBanner from "$lib/components/SecurityBanner.svelte";
   import LogsModal from "$lib/components/LogsModal.svelte";
   import SettingsModal from "$lib/components/SettingsModal.svelte";
   import { uiStore } from "$lib/stores/uiStore";
@@ -101,6 +102,7 @@
   <div
     class="bg-white/20 backdrop-blur-xl rounded-[32px] border border-white/20 p-6 flex flex-col gap-2"
   >
+    <SecurityBanner />
     <StatusCard
       status={$torStore.status}
       {totalTrafficMB}


### PR DESCRIPTION
## Summary
- warn when certificate URL or HSTS headers look insecure
- expose warning event from SecureHttpClient via AppState
- display non‑blocking warning banner in UI
- add unit test for banner

## Testing
- `npm test --silent` *(fails: Cannot read properties of undefined (reading 'deleteDatabase'))*

------
https://chatgpt.com/codex/tasks/task_e_6867b9c6e9b08333b334becac249f87c