### PR TITLE
Add system requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,6 @@ bun tauri build
 cd src-tauri && cargo test
 ```
 
-On Linux systems you may need additional development packages for the
-Rust build to succeed. Ensure `glib-2.0` development headers are
-installed (`libglib2.0-dev` on Debian/Ubuntu) before running the tests.
 
 
 ### Updating Certificates
@@ -167,6 +164,21 @@ You can influence certain backend parameters via environment variables:
 - Node.js 18+ and bun
 - Rust and Cargo (via rustup)
 - System dependencies for Tauri (see [Tauri prerequisites](https://tauri.app/v1/guides/getting-started/prerequisites))
+
+### Systemvoraussetzungen
+**Linux**
+- `libglib2.0-dev`, `pkg-config` und GTK-Entwicklungsbibliotheken
+
+**Frontend**
+- [Svelte-CLI](https://github.com/sveltejs/cli) global installiert (`bun add -g svelte`)
+
+Ohne diese Pakete schlagen `cargo test` und `bun run check` fehl. Ein Beispiel für einen fehlgeschlagenen Build findet sich in `/tmp/cargo_test.log`:
+
+```text
+error: failed to run custom build command for `glib-sys v0.15.10`
+...
+The system library `glib-2.0` required by crate `glib-sys` was not found.
+```
 
 ### Windows Build
 On Windows you also need the **Desktop development with C++** workload from the


### PR DESCRIPTION
## Summary
- document required Linux development packages and the Svelte CLI
- explain failing builds when packages are missing

## Testing
- `bun run check` *(fails: svelte-kit command not found)*
- `cargo test` *(fails: glib-2.0.pc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683dad22848333a1e58b551afb9b94