### PR TITLE
Add global error handling

### DIFF
--- a/src/__tests__/ErrorBoundary.spec.ts
+++ b/src/__tests__/ErrorBoundary.spec.ts
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock('@tauri-apps/api/tauri', () => ({ invoke: vi.fn() }));
+import { get } from 'svelte/store';
+import ErrorBoundaryTest from './ErrorBoundaryTest.svelte';
+import { uiStore } from '../lib/stores/uiStore';
+
+describe('Global error handling', () => {
+  it('captures errors from child components', () => {
+    expect(() => render(ErrorBoundaryTest)).toThrowError('Boom');
+    expect(get(uiStore).error).toBe('Boom');
+  });
+});

--- a/src/__tests__/ErrorBoundaryTest.svelte
+++ b/src/__tests__/ErrorBoundaryTest.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import Layout from '../routes/+layout.svelte';
+  import ThrowError from './ThrowError.svelte';
+</script>
+
+<Layout>
+  <ThrowError />
+</Layout>

--- a/src/__tests__/ThrowError.svelte
+++ b/src/__tests__/ThrowError.svelte
@@ -1,0 +1,3 @@
+<script lang="ts">
+  throw new Error('Boom');
+</script>

--- a/src/lib/components/ErrorDisplay.svelte
+++ b/src/lib/components/ErrorDisplay.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { uiStore } from '$lib/stores/uiStore';
+  function close() {
+    uiStore.actions.clearError();
+  }
+</script>
+{#if $uiStore.error}
+  <div role="alert" class="fixed top-4 right-4 bg-red-700 text-white px-4 py-2 rounded shadow-lg z-50 flex gap-2 items-start">
+    <span class="flex-1">{$uiStore.error}</span>
+    <button on:click={close} aria-label="Close error" class="font-bold">✕</button>
+  </div>
+{/if}

--- a/src/lib/stores/uiStore.ts
+++ b/src/lib/stores/uiStore.ts
@@ -234,6 +234,10 @@ function createUIStore() {
         }));
       }
     },
+
+    setError: (message: string) =>
+      update((state) => ({ ...state, error: message })),
+    clearError: () => update((state) => ({ ...state, error: null })),
   };
 
   // Load settings on initialization

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,22 @@
-<script>
-	import '../app.css';
+<script lang="ts">
+        import '../app.css';
+        import ErrorDisplay from '$lib/components/ErrorDisplay.svelte';
+        import { uiStore } from '$lib/stores/uiStore';
+        import { onMount } from 'svelte';
+
+        onMount(() => {
+                const handler = (e: ErrorEvent) => uiStore.actions.setError(e.message);
+                const rej = (e: PromiseRejectionEvent) => uiStore.actions.setError(e.reason?.message ?? String(e.reason));
+                window.addEventListener('error', handler);
+                window.addEventListener('unhandledrejection', rej);
+                return () => {
+                        window.removeEventListener('error', handler);
+                        window.removeEventListener('unhandledrejection', rej);
+                };
+        });
 </script>
 
 <main>
-	<slot />
+        <ErrorDisplay />
+        <slot />
 </main>


### PR DESCRIPTION
## Summary
- centralize UI error handling via ErrorDisplay
- expose `setError` and `clearError` actions
- catch global errors in the app layout
- add regression test for global error handler

## Testing
- `npm test` *(fails: expected null to be 'Boom', others)*

------
https://chatgpt.com/codex/tasks/task_e_68683dae61648333858190c417eddfb1