### PR TITLE
Enable manual workflow trigger and add Linux deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Manual trigger reason'
+        required: false
 
 jobs:
   backend:
@@ -64,6 +69,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest


### PR DESCRIPTION
## Summary
- allow manual dispatch of CI workflow
- install required system libraries for Tauri bundling on Linux

## Testing
- `bun run check`
- `cargo test` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683daed8a88333a64e5bec785e1789