### PR TITLE
Improve tor_manager error context

### DIFF
--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -143,7 +143,10 @@ async fn bridge_parse_error() {
 async fn lookup_country_error() {
     let manager: TorManager<MockTorClient> = TorManager::new();
     let res = manager.lookup_country_code("?.?.?.?").await;
-    assert!(matches!(res, Err(Error::Lookup(_))));
+    match res {
+        Err(Error::Lookup(msg)) => assert!(msg.contains("?.?.?.?")),
+        _ => panic!("expected lookup error"),
+    }
 }
 
 #[tokio::test]
@@ -173,7 +176,10 @@ async fn new_identity_reconfigure_error() {
     let manager: TorManager<MockTorClient> = TorManager::new();
     manager.connect().await.unwrap();
     let res = manager.new_identity().await;
-    assert!(matches!(res, Err(Error::Identity(_))));
+    match res {
+        Err(Error::Identity(msg)) => assert!(msg.contains("reconf")),
+        _ => panic!("expected identity error"),
+    }
 }
 
 #[tokio::test]
@@ -185,5 +191,8 @@ async fn new_identity_build_error() {
     let manager: TorManager<MockTorClient> = TorManager::new();
     manager.connect().await.unwrap();
     let res = manager.new_identity().await;
-    assert!(matches!(res, Err(Error::Circuit(_))));
+    match res {
+        Err(Error::Circuit(msg)) => assert!(msg.contains("build")),
+        _ => panic!("expected circuit error"),
+    }
 }


### PR DESCRIPTION
## Summary
- expand error messages for `Error::{Circuit, Identity, Lookup}` with helpful context
- update unit tests to check the new messages

## Testing
- `cargo test --tests` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68684b6b12b08333a9cd387fd7f0d67e