### PR TITLE
Improve accessibility and keyboard flow

### DIFF
--- a/src/__tests__/PageFlow.e2e.spec.ts
+++ b/src/__tests__/PageFlow.e2e.spec.ts
@@ -23,4 +23,26 @@ describe('Main page flow', () => {
     await fireEvent.click(screen.getByRole('button', { name: /close logs/i }));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
+
+  it('supports keyboard navigation for modals', async () => {
+    render(Page);
+
+    const logsButton = screen.getByRole('button', { name: /logs/i });
+    logsButton.focus();
+    await fireEvent.keyDown(logsButton, { key: 'Enter' });
+    await screen.findByRole('dialog');
+
+    const dialog = screen.getByRole('dialog');
+    await fireEvent.keyDown(dialog, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    settingsButton.focus();
+    await fireEvent.keyDown(settingsButton, { key: 'Enter' });
+    await screen.findByRole('dialog');
+
+    const dialog2 = screen.getByRole('dialog');
+    await fireEvent.keyDown(dialog2, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
 });

--- a/src/lib/components/ActionCard.svelte
+++ b/src/lib/components/ActionCard.svelte
@@ -55,7 +55,7 @@
 
 </script>
 
-<div class="bg-black/20 rounded-xl p-6">
+<div class="bg-black/20 rounded-xl p-6" tabindex="0" role="region">
 	<!-- Error Message -->
 {#if $torStore.errorMessage}
                 <div class="mb-4 p-3 bg-red-900/30 border border-red-700/50 text-red-300 rounded-lg flex items-center gap-2" role="alert" aria-live="assertive">

--- a/src/lib/components/IdlePanel.svelte
+++ b/src/lib/components/IdlePanel.svelte
@@ -18,7 +18,7 @@
 	}
 </script>
 
-<div class="bg-black/20 rounded-xl p-6">
+<div class="bg-black/20 rounded-xl p-6" tabindex="0" role="region">
 	<div class="flex flex-col items-center gap-3">
 		<!-- Progress Bar -->
                 <div

--- a/src/lib/components/LogsModal.svelte
+++ b/src/lib/components/LogsModal.svelte
@@ -22,15 +22,19 @@
        let isClearing = false;
        let logFilePath = '';
        let closeButton: HTMLButtonElement | null = null;
+       let previouslyFocused: HTMLElement | null = null;
 
         $: filteredByType = activeTab === 'all' ? logs : logs.filter(log => log.type === activeTab);
         $: filteredLogs = levelFilter === 'all' ? filteredByType : filteredByType.filter(log => log.level === levelFilter);
 
-        $: if (show) {
-                loadLogs();
-                fetchLogFilePath();
-                tick().then(() => closeButton && closeButton.focus());
-        }
+       $: if (show) {
+               previouslyFocused = document.activeElement as HTMLElement;
+               loadLogs();
+               fetchLogFilePath();
+               tick().then(() => closeButton && closeButton.focus());
+       } else if (previouslyFocused) {
+               tick().then(() => previouslyFocused && previouslyFocused.focus());
+       }
 
         async function loadLogs() {
                 isLoading = true;
@@ -108,12 +112,14 @@
 <svelte:window on:keydown={handleKeydown} />
 
 {#if show}
-        <div class="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+        <div class="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4" on:click={() => dispatch('close')} tabindex="-1">
                 <div
                         class="bg-black/80 backdrop-blur-3xl rounded-2xl border border-white/10 w-full max-w-4xl max-h-[80vh] overflow-hidden"
                         role="dialog"
                         aria-modal="true"
                         aria-labelledby="logs-modal-title"
+                        tabindex="0"
+                        on:click|stopPropagation
                 >
 			<!-- Header -->
 			<div class="flex items-center justify-between p-6 border-b border-white/10">

--- a/src/lib/components/SecurityBanner.svelte
+++ b/src/lib/components/SecurityBanner.svelte
@@ -8,7 +8,7 @@
 </script>
 
 {#if $torStore.securityWarning}
-<div class="bg-yellow-900/80 text-yellow-200 p-2 rounded-lg mb-3 flex items-center justify-between" role="alert">
+<div class="bg-yellow-900/80 text-yellow-200 p-2 rounded-lg mb-3 flex items-center justify-between" role="alert" tabindex="0">
   <span class="text-sm">{$torStore.securityWarning}</span>
   <button on:click={dismiss} aria-label="Dismiss warning" class="ml-2">
     <X size={14} />

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -20,8 +20,10 @@
   const dispatch = createEventDispatcher();
   let showTorrcEditor = false; // This will be unused for now
   let closeButton: HTMLButtonElement | null = null;
+  let previouslyFocused: HTMLElement | null = null;
 
   $: if (show) {
+    previouslyFocused = document.activeElement as HTMLElement;
     selectedBridges = [...$uiStore.settings.bridges];
     torrcConfig = $uiStore.settings.torrcConfig;
     workerListString = $uiStore.settings.workerList.join("\n");
@@ -29,11 +31,12 @@
     exitCountry = $uiStore.settings.exitCountry ?? null;
     uiStore.actions.setExitCountry(exitCountry);
     tick().then(() => closeButton && closeButton.focus());
+  } else if (previouslyFocused) {
+    tick().then(() => previouslyFocused && previouslyFocused.focus());
   }
 
   function handleKeyDown(event: KeyboardEvent) {
     if (event.key === "Escape") {
-      show = false;
       dispatch("close");
     }
   }
@@ -67,25 +70,25 @@
 {#if show}
   <div
     class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-    on:click|stopPropagation={() => (show = false)}
-    role="dialog"
-    aria-modal="true"
-    aria-labelledby="settings-modal-title"
-    on:keydown={handleKeyDown}
+    on:click={() => dispatch('close')}
+    tabindex="-1"
   >
     <section
       class="bg-black/40 backdrop-blur-3xl rounded-2xl border border-white/10 w-[90%] max-w-2xl min-h-[500px] p-6 flex flex-col"
       on:click|stopPropagation
       on:keydown={handleKeyDown}
-      role="document"
-    >
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="settings-modal-title"
+      tabindex="0"
+      >
       <div class="flex justify-between items-center mb-4 shrink-0">
         <h2 id="settings-modal-title" class="text-2xl font-semibold">
           Settings
         </h2>
         <button
           class="text-gray-100 hover:text-white transition-colors"
-          on:click={() => (show = false)}
+          on:click={() => dispatch('close')}
           aria-label="Close settings"
           bind:this={closeButton}
         >

--- a/src/lib/components/StatusCard.svelte
+++ b/src/lib/components/StatusCard.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <!-- Status Card -->
-<div class="bg-black/20 rounded-xl p-6">
+<div class="bg-black/20 rounded-xl p-6" tabindex="0" role="region">
   <div class="flex items-center justify-between gap-6">
     <!-- Status Section -->
     <div class="flex items-center gap-4">

--- a/src/lib/components/TorChain.svelte
+++ b/src/lib/components/TorChain.svelte
@@ -69,7 +69,7 @@
 	}
 </script>
 
-<div class="bg-black/20 rounded-xl p-6">
+<div class="bg-black/20 rounded-xl p-6" tabindex="0" role="region">
 	<!-- Single Row with Title, Dropdowns and Active Switch -->
 	<div class="grid grid-cols-5 gap-4 mb-4 items-center h-8">
 		<!-- Tor Chain Title -->


### PR DESCRIPTION
## Summary
- add `tabindex` and ARIA `role` to card components
- manage focus when opening/closing Logs and Settings modals
- close modals on backdrop click
- extend `PageFlow` e2e test to cover keyboard navigation

## Testing
- `bun run check`
- `cargo check` *(fails: glib-2.0 missing)*
- `bun test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6868f3cdc2908333967bd0ae936e0b2c