### PR TITLE
Add central log hook and metric placeholders

### DIFF
--- a/docs/NextSteps.md
+++ b/docs/NextSteps.md
@@ -176,6 +176,21 @@
   - Structured logging
   - Log aggregation
   - Alerting on critical errors
+  - Example log document:
+
+```json
+{
+  "timestamp": "2025-07-04T12:00:00Z",
+  "level": "INFO",
+  "service": "torwell-desktop",
+  "host": "workstation-01",
+  "message": "Circuit established",
+  "metrics": {
+    "circuit_build_ms": 1300,
+    "circuit_count": 5
+  }
+}
+```
 
 ### 5.3 Vor dem Release
 Bevor ein neuer Build veröffentlicht wird, sollten die folgenden Punkte abgearbeitet werden:

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -106,7 +106,7 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
         match tor_manager
             .connect_with_backoff(
                 5,
-                Duration::from_secs(60),
+                Duration::from_secs(60), // place to capture circuit build duration metrics
                 |attempt, delay, err| {
                     let err_str = err.to_string();
                     let sc = state_clone.clone();
@@ -254,7 +254,7 @@ pub async fn get_traffic_stats(state: State<'_, AppState>) -> Result<TrafficStat
 pub async fn get_metrics(state: State<'_, AppState>) -> Result<Metrics> {
     track_call("get_metrics").await;
     check_api_rate()?;
-    let circ = state.tor_manager.circuit_metrics().await?;
+    let circ = state.tor_manager.circuit_metrics().await?; // capture more metrics like build time when available
     let mut sys = sysinfo::System::new();
     let pid = sysinfo::get_current_pid().map_err(|e| Error::Io(e.to_string()))?;
     sys.refresh_process(pid);
@@ -297,7 +297,7 @@ pub async fn get_metrics(state: State<'_, AppState>) -> Result<Metrics> {
 pub async fn new_identity(app_handle: tauri::AppHandle, state: State<'_, AppState>) -> Result<()> {
     track_call("new_identity").await;
     check_api_rate()?;
-    state.tor_manager.new_identity().await?;
+    state.tor_manager.new_identity().await?; // potential metric: measure time to build new circuit
     // Emit event to update frontend
     app_handle.emit_all(
         "tor-status-update",

--- a/src-tauri/src/secure_http.rs
+++ b/src-tauri/src/secure_http.rs
@@ -8,6 +8,7 @@ use rustls::version::{TLS12, TLS13};
 use rustls::{ClientConfig, RootCertStore};
 use rustls_pemfile as pemfile;
 use serde::Deserialize;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
@@ -343,6 +344,13 @@ impl SecureHttpClient {
     pub async fn get_text(&self, url: &str) -> reqwest::Result<String> {
         let resp = self.get_with_hsts_check(url).await?;
         resp.text().await
+    }
+
+    /// Send JSON data to an HTTP endpoint using the pinned TLS configuration.
+    pub async fn post_json(&self, url: &str, body: &Value) -> reqwest::Result<()> {
+        let client = { self.client.lock().await.clone() };
+        client.post(url).json(body).send().await?;
+        Ok(())
     }
 
     pub async fn reload_certificates(&self) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- add optional hook for forwarding logs over HTTP
- mark potential spots for capturing advanced metrics
- document log entry structure for central server

## Testing
- `bun run check` *(fails: svelte-kit not found)*
- `cargo test` *(fails: glib-2.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_6868f73151d8833390955f10ce06d7fa