### PR TITLE
Add release workflow and update documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run tauri build
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-bundle
+          path: src-tauri/target/release/bundle
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - name: Extract version
+        id: version
+        run: |
+          PKG=$(jq -r .version package.json)
+          CARGO=$(grep -m1 '^version' src-tauri/Cargo.toml | cut -d '"' -f2)
+          if [ "$PKG" != "$CARGO" ]; then
+            echo "::error::version mismatch" && exit 1
+          fi
+          echo "version=$PKG" >> $GITHUB_OUTPUT
+      - name: Update changelog
+        run: ./scripts/update_changelog.sh ${{ steps.version.outputs.version }}
+      - name: Commit changelog
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add docs/Changelog.md
+          git commit -m "chore: update changelog for ${{ steps.version.outputs.version }}"
+          git push
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ steps.version.outputs.version }}
+          body: |
+            See CHANGELOG for details.
+          files: dist/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -155,3 +155,15 @@ sicherstellt, dass immer ein gültiges Zertifikat vorliegt.
 
 Dieser Workflow stellt sicher, dass die Zertifikate regelmäßig erneuert werden
 und Probleme frühzeitig erkannt werden.
+
+## Hinweise zur Zertifikats-Rotation
+
+- Bewahre das bisherige PEM unter `src-tauri/certs/backup.pem` auf, um bei
+  Problemen kurzfristig darauf zurückgreifen zu können.
+- Prüfe das Ablaufdatum des neuen Zertifikats vor dem Austausch mit
+  `openssl x509 -in <datei> -noout -dates`.
+- Dokumentiere jedes Rotationsdatum in einer zentralen Liste, damit ersichtlich
+  bleibt, wann welches Zertifikat aktiv war.
+- Sollte keine Hintergrundaufgabe laufen, kann `schedule_updates` nach dem
+  Austausch manuell angestoßen werden, um den neuen PEM-Inhalt sofort
+  einzulesen.

--- a/docs/NextSteps.md
+++ b/docs/NextSteps.md
@@ -151,16 +151,27 @@
 ### 5.1 CI/CD Pipeline
 
 #### 5.1.1 Build Automation
-- **Requirements**:
-  - Automated builds on tag
-  - Versioned artifacts
-  - Release notes generation
+Der Build-Prozess soll vollautomatisch ablaufen, sobald ein neues Tag
+erstellt wird. Der Workflow läuft in folgenden Schritten ab:
+1. GitHub Actions wird durch Tags nach dem Muster `v*` ausgelöst.
+2. Node, Bun und der Rust-Toolchain werden installiert.
+3. Die Versionsnummer aus `package.json` und `Cargo.toml` wird mit dem
+   Tag verglichen.
+4. Über `bun run tauri build` werden plattformabhängige Pakete erstellt.
+5. Ein Skript aktualisiert die `docs/Changelog.md` um die neuesten
+   Commits.
+6. Die erzeugten Artefakte werden an ein Release angehängt.
 
 #### 5.1.2 Deployment Strategy
-- **Implementation**:
-  - Staging environment
-  - Canary releases
-  - Rollback procedures
+Nach dem erfolgreichen Build erfolgt die Verteilung in mehreren Stufen:
+1. Zuerst wird ein Staging-Release bereitgestellt und automatisierte
+   Tests laufen durch.
+2. Anschließend wird eine Canary-Version für ausgewählte Nutzer
+   veröffentlicht.
+3. Führen die Tests zu keinem Fehler, wird der Rollout für alle Nutzer
+   freigegeben.
+4. Bei Problemen kann jederzeit auf das vorherige Release-Tag
+   zurückgerollt werden.
 
 ### 5.2 Monitoring & Logging
 

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+VERSION="$1"
+CHANGELOG="docs/Changelog.md"
+
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+DATE=$(date +%Y-%m-%d)
+PREVIOUS_TAG=$(git tag --sort=-v:refname | sed -n '2p')
+
+{
+  echo "## [$VERSION] - $DATE"
+  if [ -n "$PREVIOUS_TAG" ]; then
+    git log "$PREVIOUS_TAG"..HEAD --pretty=format:"- %s" --no-merges
+  else
+    git log --pretty=format:"- %s" --no-merges
+  fi
+  echo
+} > .changelog.tmp
+
+cat "$CHANGELOG" >> .changelog.tmp
+mv .changelog.tmp "$CHANGELOG"


### PR DESCRIPTION
## Summary
- convert CI/CD bullet list into step-by-step procedure
- describe cert rotation hints
- add GitHub Actions workflow for tag releases
- add changelog updater script

## Testing
- `bun run check` *(fails: svelte-kit not found)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686911e085e0833397833eb6ce9c1dc2