### PR TITLE
Handle resource limits and show warnings

### DIFF
--- a/src-tauri/tests/state_tests.rs
+++ b/src-tauri/tests/state_tests.rs
@@ -1,0 +1,89 @@
+use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+use torwell84::secure_http::SecureHttpClient;
+use torwell84::session::SessionManager;
+use torwell84::state::AppState;
+use torwell84::tor_manager::{TorClientBehavior, TorClientConfig, TorManager};
+
+#[derive(Clone)]
+struct DummyClient {
+    retired: Arc<StdMutex<bool>>,
+}
+
+static CLIENTS: Lazy<StdMutex<VecDeque<DummyClient>>> =
+    Lazy::new(|| StdMutex::new(VecDeque::new()));
+
+impl DummyClient {
+    fn new(flag: Arc<StdMutex<bool>>) -> Self {
+        Self { retired: flag }
+    }
+
+    fn push(client: DummyClient) {
+        CLIENTS.lock().unwrap().push_back(client);
+    }
+}
+
+#[async_trait]
+impl TorClientBehavior for DummyClient {
+    async fn create_bootstrapped(_c: TorClientConfig) -> std::result::Result<Self, String> {
+        Ok(CLIENTS.lock().unwrap().pop_front().expect("no client"))
+    }
+
+    async fn create_bootstrapped_with_progress<P>(
+        c: TorClientConfig,
+        _p: &mut P,
+    ) -> std::result::Result<Self, String>
+    where
+        P: FnMut(u8, String) + Send,
+    {
+        Self::create_bootstrapped(c).await
+    }
+
+    fn reconfigure(&self, _c: &TorClientConfig) -> std::result::Result<(), String> {
+        Ok(())
+    }
+
+    fn retire_all_circs(&self) {
+        *self.retired.lock().unwrap() = true;
+    }
+
+    async fn build_new_circuit(&self) -> std::result::Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn update_metrics_closes_circuits_on_limit() {
+    let flag = Arc::new(StdMutex::new(false));
+    DummyClient::push(DummyClient::new(flag.clone()));
+    let manager: TorManager<DummyClient> = TorManager::new();
+    manager.connect().await.unwrap();
+
+    let state = AppState {
+        tor_manager: Arc::new(manager),
+        http_client: Arc::new(SecureHttpClient::new_default().unwrap()),
+        log_file: PathBuf::from("state.log"),
+        log_lock: Arc::new(Mutex::new(())),
+        retry_counter: Arc::new(Mutex::new(0)),
+        max_log_lines: Arc::new(Mutex::new(1000)),
+        memory_usage: Arc::new(Mutex::new(0)),
+        circuit_count: Arc::new(Mutex::new(0)),
+        latency_ms: Arc::new(Mutex::new(0)),
+        max_memory_mb: 1,
+        max_circuits: 1,
+        session: SessionManager::new(Duration::from_secs(60)),
+        app_handle: Arc::new(Mutex::new(None)),
+    };
+    let _ = tokio::fs::remove_file("state.log").await;
+    state.update_metrics(2 * 1024 * 1024, 2).await;
+
+    assert!(*flag.lock().unwrap());
+    let logs = state.read_logs().await.unwrap();
+    assert!(!logs.is_empty());
+}

--- a/src/__tests__/StatusCard.spec.ts
+++ b/src/__tests__/StatusCard.spec.ts
@@ -48,4 +48,14 @@ describe('StatusCard', () => {
     expect(getByText('55 MB')).toBeInTheDocument();
     expect(getByText('3')).toBeInTheDocument();
   });
+
+  it('shows security warnings', async () => {
+    const { getByRole } = render(StatusCard, {
+      props: { status: 'CONNECTED', totalTrafficMB: 0, pingMs: undefined }
+    });
+    const { torStore } = await import('../lib/stores/torStore');
+    torStore.update((s) => ({ ...s, securityWarning: 'overload' }));
+    await Promise.resolve();
+    expect(getByRole('alert')).toHaveTextContent('overload');
+  });
 });

--- a/src/lib/components/StatusCard.svelte
+++ b/src/lib/components/StatusCard.svelte
@@ -149,4 +149,7 @@
       </button>
     </div>
   </div>
+  {#if $torStore.securityWarning}
+    <p class="text-yellow-200 text-xs mt-2" role="alert">{$torStore.securityWarning}</p>
+  {/if}
 </div>


### PR DESCRIPTION
## Summary
- close all circuits when limits exceeded
- log and emit warnings from `update_metrics`
- display warnings in StatusCard
- add integration test for limit handling
- test security warning display

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686911db457883339b95cfb0c6e8a5de