### PR TITLE
Automate signed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           fi
           echo "version=$PKG" >> $GITHUB_OUTPUT
       - name: Update changelog
-        run: ./scripts/update_changelog.sh ${{ steps.version.outputs.version }}
+        run: ./scripts/update_changelog.sh
       - name: Commit changelog
         run: |
           git config user.name github-actions
@@ -61,6 +61,18 @@ jobs:
           git add docs/Changelog.md
           git commit -m "chore: update changelog for ${{ steps.version.outputs.version }}"
           git push
+      - name: Import signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --batch --import
+      - name: Sign artifacts
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          find dist -type f -not -name '*.asc' -not -name '*.sig' -print0 | while IFS= read -r -d '' file; do
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" -ab "$file"
+          done
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/README.md
+++ b/README.md
@@ -209,6 +209,14 @@ relevant:
 - `TORWELL_FALLBACK_CERT_URL` – Optionale Ausweich-URL für Updates
 - `TORWELL_SESSION_TTL` – Lebensdauer der Authentifizierungstokens
 
+### Creating a Release
+
+1. Versionsnummer in `package.json` und `src-tauri/Cargo.toml` aktualisieren.
+2. `./scripts/update_changelog.sh` ausführen, um das Changelog zu aktualisieren.
+3. Änderungen committen und einen Tag `vX.Y.Z` erstellen.
+4. Tag und Branch pushen – der Release-Workflow baut und signiert die Pakete
+   automatisch und lädt sie zu GitHub Releases hoch.
+
 ## Installation
 
 ### Windows

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 set -e
 
-VERSION="$1"
 CHANGELOG="docs/Changelog.md"
 
-if [ -z "$VERSION" ]; then
-  echo "Usage: $0 <version>" >&2
+# Read version from package.json and Cargo.toml and ensure they match
+PKG_VERSION=$(jq -r .version package.json)
+CARGO_VERSION=$(grep -m1 '^version' src-tauri/Cargo.toml | cut -d '"' -f2)
+
+if [ "$PKG_VERSION" != "$CARGO_VERSION" ]; then
+  echo "Version mismatch between package.json and Cargo.toml" >&2
   exit 1
 fi
+
+VERSION="$PKG_VERSION"
 
 DATE=$(date +%Y-%m-%d)
 PREVIOUS_TAG=$(git tag --sort=-v:refname | sed -n '2p')


### PR DESCRIPTION
## Summary
- sign artifacts in release workflow before uploading
- read package version automatically when updating changelog
- document release process in README

## Testing
- `bun run check` *(fails: svelte-kit not found)*
- `cargo test` *(fails: missing glib-2.0 system library)*

------
https://chatgpt.com/codex/tasks/task_e_686916f6093c833384179a18f5fe29bb