### PR TITLE
Improve TLS and HSTS enforcement

### DIFF
--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -99,6 +99,22 @@ export TORWELL_CERT_PATH=src-tauri/certs/custom.pem
 bun tauri dev
 ```
 
+### HSTS und TLS-Versionen
+
+Der Eintrag `min_tls_version` in `cert_config.json` bestimmt die minimale
+TLS-Version, die der Client akzeptiert. Zulässig sind die Werte `"1.2"` und
+`"1.3"`. Wird kein Wert angegeben oder ein niedrigerer Wert gesetzt, erzwingt
+`SecureHttpClient` automatisch TLS&nbsp;1.2.
+
+Nach jedem HTTPS-Aufruf wird zudem geprüft, ob der Server den
+`Strict-Transport-Security`-Header mitsendet. Fehlt dieser Header, erscheint eine
+Warnmeldung im Log. Um HTTP-Downgrades zu verhindern und die Warnung zu
+vermeiden, sollte der Webserver beispielsweise folgenden Header senden:
+
+```
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+```
+
 ## Geplante Zertifikatsrotation
 
 Um eine durchgehende Vertrauenskette sicherzustellen, werden die


### PR DESCRIPTION
## Summary
- filter cipher suites in `strong_provider` and keep only TLS1.2+ suites
- add helper to check the HSTS header and apply it to all HTTP methods
- emit HSTS warning for POST requests
- document configuring `min_tls_version` and HSTS headers

## Testing
- `cargo test --tests` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_686916f094e88333a669ec91771966d7