### PR TITLE
Add tray warnings when limits exceeded

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -144,4 +144,5 @@ Das Backend akzeptiert verschiedene Umgebungsvariablen zur Laufzeitkonfiguration
 - `TORWELL_MAX_LOG_LINES` – Maximale Anzahl von Logzeilen, die in `torwell.log` aufbewahrt werden (Standard `1000`).
 - `TORWELL_MAX_MEMORY_MB` – Schwellenwert für Speichernutzung, ab dem Warnungen ausgegeben werden (Standard `1024`).
 - `TORWELL_MAX_CIRCUITS` – Maximale Anzahl erlaubter paralleler Tor-Circuits (Standard `20`).
+- Bei Überschreitung dieser Limits erscheint ein Warnhinweis im Systemtray-Menü.
 

--- a/docs/NextSteps.md
+++ b/docs/NextSteps.md
@@ -82,6 +82,7 @@
   - Implement memory monitoring
   - Add circuit cleanup routines
   - Set memory usage limits
+  - Bei Überschreitung wird nun eine Warnung im Systemtray angezeigt
 
 ## 3. Frontend Improvements
 

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -81,6 +81,7 @@ fn mock_state() -> AppState<MockTorClient> {
         max_memory_mb: 1024,
         max_circuits: 20,
         session: SessionManager::new(std::time::Duration::from_secs(60)),
+        tray_warning: Arc::new(Mutex::new(None)),
     }
 }
 

--- a/src-tauri/tests/fuzz_commands.rs
+++ b/src-tauri/tests/fuzz_commands.rs
@@ -46,6 +46,7 @@ fn mock_state() -> AppState<MockTorClient> {
         max_memory_mb: 1024,
         max_circuits: 20,
         session: SessionManager::new(std::time::Duration::from_secs(60)),
+        tray_warning: Arc::new(Mutex::new(None)),
     }
 }
 


### PR DESCRIPTION
## Summary
- show memory and circuit warnings in the system tray
- store warning text in AppState
- verify tray warning logic in state tests
- mention tray behaviour in docs

## Testing
- `cargo test --quiet` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686916f3980c8333b6c27fb512004736