### PR TITLE
Add PenTest plan and fuzzing instructions

### DIFF
--- a/docs/PenTestPlan.md
+++ b/docs/PenTestPlan.md
@@ -1,0 +1,29 @@
+# Penetration Test Plan
+
+This plan defines the goals and boundaries for penetration testing of Torwell84.
+
+## Objectives
+- Discover vulnerabilities in the network stack and IPC interface.
+- Verify correct enforcement of session handling and rate limits.
+- Validate TLS configuration and certificate pinning.
+- Ensure untrusted input is sanitized throughout the command handlers.
+
+## Scope
+- `src-tauri/src/commands.rs` and related modules that expose IPC endpoints.
+- Session management in `src-tauri/src/session.rs`.
+- Network logic in `src-tauri/src/tor_manager.rs`.
+- Tauri front end to backend communication.
+- No testing of third-party services beyond their documented interfaces.
+
+## IPC Fuzzing
+`src-tauri/tests/fuzz_commands.rs` contains a small fuzzing harness that
+invokes command handlers with random values. Run it with:
+
+```bash
+cargo test --test fuzz_commands -- --nocapture
+```
+
+Extend this file to cover additional commands by generating random inputs
+and checking for panics or validation errors. The mock Tor client shown in
+`fuzz_commands.rs` isolates network calls so only the command handlers are
+exercised.


### PR DESCRIPTION
## Summary
- document penetration testing objectives, scope and IPC fuzzing

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --features ''` *(fails: glib-2.0 not found)*
- `bun run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694631ded88333aeb8c32e668099e6