### PR TITLE
Add tor connection error and bridge tests

### DIFF
--- a/src/__tests__/SettingsModal.e2e.spec.ts
+++ b/src/__tests__/SettingsModal.e2e.spec.ts
@@ -49,4 +49,23 @@ describe('SettingsModal persistence', () => {
     expect(input.value).toBe('123');
     expect(select.value).toBe('DE');
   });
+
+  it('applies bridges via store and backend', async () => {
+  const { getByLabelText, getByRole } = render(SettingsModal, { props: { show: true } });
+
+  await fireEvent.click(getByLabelText(BRIDGE));
+  await fireEvent.click(getByRole('button', { name: 'Apply bridge selection' }));
+
+  const { uiStore } = await import('../lib/stores/uiStore');
+  await Promise.resolve();
+
+  const { get } = await import('svelte/store');
+  expect(get(uiStore).settings.bridges).toContain(BRIDGE);
+
+  const { invoke } = await import('@tauri-apps/api/tauri');
+  expect(invoke).toHaveBeenCalledWith('set_bridges', { bridges: [BRIDGE] });
+
+  const stored = await db.settings.get(1);
+  expect(stored?.bridges).toContain(BRIDGE);
+});
 });

--- a/src/__tests__/TorStore.spec.ts
+++ b/src/__tests__/TorStore.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+let statusCallback: (event: any) => void = () => {};
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn((event: string, cb: any) => {
+    if (event === 'tor-status-update') statusCallback = cb;
+  })
+}));
+vi.mock('@tauri-apps/api/tauri', () => ({ invoke: vi.fn() }));
+
+import { torStore } from '../lib/stores/torStore';
+
+describe('torStore', () => {
+  it('sets status to ERROR on failed connection', () => {
+    statusCallback({ payload: { status: 'ERROR', errorMessage: 'fail' } });
+    expect(get(torStore).status).toBe('ERROR');
+  });
+});


### PR DESCRIPTION
## Summary
- test torStore sets status to ERROR when connection fails
- verify bridges from SettingsModal are stored via store and backend

## Testing
- `npm test` *(fails: 6 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68694637462c8333aa16ed1115a258ba