### PR TITLE
Implement metrics chart

### DIFF
--- a/src/__tests__/ActionCard.spec.ts
+++ b/src/__tests__/ActionCard.spec.ts
@@ -1,19 +1,19 @@
-import { vi, describe, it, expect } from 'vitest';
-vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
-vi.mock('@tauri-apps/api', () => ({ invoke: vi.fn() }));
-import { render, fireEvent } from '@testing-library/svelte';
-import ActionCard from '../lib/components/ActionCard.svelte';
-import { invoke } from '@tauri-apps/api';
+import { vi, describe, it, expect } from "vitest";
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn() }));
+vi.mock("@tauri-apps/api", () => ({ invoke: vi.fn() }));
+import { render, fireEvent } from "@testing-library/svelte";
+import ActionCard from "../lib/components/ActionCard.svelte";
+import { invoke } from "@tauri-apps/api";
 
 // Reset store between tests by importing after test to ensure fresh instance
-import { torStore } from '../lib/stores/torStore';
+import { torStore } from "../lib/stores/torStore";
 
-describe('ActionCard', () => {
-  it('renders Connect button when stopped', () => {
+describe("ActionCard", () => {
+  it("renders Connect button when stopped", () => {
     torStore.set({
-      status: 'DISCONNECTED',
+      status: "DISCONNECTED",
       bootstrapProgress: 0,
-      bootstrapMessage: '',
+      bootstrapMessage: "",
       errorMessage: null,
       securityWarning: null,
       retryCount: 0,
@@ -21,25 +21,28 @@ describe('ActionCard', () => {
       memoryUsageMB: 0,
       circuitCount: 0,
       pingMs: undefined,
+      metrics: [],
     });
 
     const { getByRole } = render(ActionCard);
-    expect(getByRole('button', { name: /connect to tor/i })).toBeInTheDocument();
+    expect(
+      getByRole("button", { name: /connect to tor/i }),
+    ).toBeInTheDocument();
   });
 
-  it('dispatches openLogs event when Logs button is clicked', async () => {
+  it("dispatches openLogs event when Logs button is clicked", async () => {
     const { getByRole, component } = render(ActionCard);
     const handler = vi.fn();
-    component.$on('openLogs', handler);
-    await fireEvent.click(getByRole('button', { name: /open logs/i }));
+    component.$on("openLogs", handler);
+    await fireEvent.click(getByRole("button", { name: /open logs/i }));
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
-  it('calls disconnect when Disconnect button clicked', async () => {
+  it("calls disconnect when Disconnect button clicked", async () => {
     torStore.set({
-      status: 'CONNECTED',
+      status: "CONNECTED",
       bootstrapProgress: 0,
-      bootstrapMessage: '',
+      bootstrapMessage: "",
       errorMessage: null,
       securityWarning: null,
       retryCount: 0,
@@ -47,10 +50,13 @@ describe('ActionCard', () => {
       memoryUsageMB: 0,
       circuitCount: 0,
       pingMs: undefined,
+      metrics: [],
     });
 
     const { getByRole } = render(ActionCard);
-    await fireEvent.click(getByRole('button', { name: /disconnect from tor/i }));
-    expect(invoke).toHaveBeenCalledWith('disconnect');
+    await fireEvent.click(
+      getByRole("button", { name: /disconnect from tor/i }),
+    );
+    expect(invoke).toHaveBeenCalledWith("disconnect");
   });
 });

--- a/src/lib/components/MetricsChart.svelte
+++ b/src/lib/components/MetricsChart.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { MetricPoint } from "$lib/stores/torStore";
+  export let metrics: MetricPoint[] = [];
+  const width = 120;
+  const height = 40;
+
+  function buildPath(data: MetricPoint[]): string {
+    if (data.length === 0) return "";
+    const maxVal = Math.max(...data.map((d) => d.memoryMB), 1);
+    const step = width / Math.max(data.length - 1, 1);
+    let d = `M0 ${height}`;
+    data.forEach((pt, idx) => {
+      const x = idx * step;
+      const y = height - (pt.memoryMB / maxVal) * height;
+      d += ` L${x} ${y}`;
+    });
+    d += ` L${width} ${height} Z`;
+    return d;
+  }
+
+  $: pathData = buildPath(metrics);
+</script>
+
+<svg {width} {height} class="text-green-400">
+  {#if pathData}
+    <path
+      d={pathData}
+      fill="currentColor"
+      fill-opacity="0.3"
+      stroke="currentColor"
+      stroke-width="1"
+    />
+  {/if}
+</svg>

--- a/src/lib/components/StatusCard.svelte
+++ b/src/lib/components/StatusCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Activity, Zap } from "lucide-svelte";
   import { invoke } from "$lib/api";
+  import MetricsChart from "./MetricsChart.svelte";
 
   export let status;
   export let totalTrafficMB = 0;
@@ -9,8 +10,10 @@
   import { torStore } from "$lib/stores/torStore";
   let memoryMB: number;
   let circuitCount: number;
+  let metrics = [];
   $: memoryMB = $torStore.memoryUsageMB;
   $: circuitCount = $torStore.circuitCount;
+  $: metrics = $torStore.metrics;
 
   let isPinging = false;
 
@@ -29,7 +32,7 @@
     try {
       const result = (await invoke("ping_host", {
         host: "google.com",
-        count: 5
+        count: 5,
       })) as number;
       pingMs = result;
     } catch (error) {
@@ -150,6 +153,11 @@
     </div>
   </div>
   {#if $torStore.securityWarning}
-    <p class="text-yellow-200 text-xs mt-2" role="alert">{$torStore.securityWarning}</p>
+    <p class="text-yellow-200 text-xs mt-2" role="alert">
+      {$torStore.securityWarning}
+    </p>
   {/if}
+  <div class="mt-2">
+    <MetricsChart {metrics} />
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- buffer metrics history in `torStore`
- draw chart of recent memory usage via new `MetricsChart` component
- display chart in `StatusCard`
- update tests for new store field

## Testing
- `npx vitest run` *(fails: NotFoundError: The operation failed because the requested database object could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6869463a1f4883338189d964dea7a68b