### PR TITLE
Enhance tray status

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -154,6 +154,7 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
                 ) {
                     log::error!("Failed to emit status update: {}", e);
                 }
+                state_clone.update_tray_menu().await;
             }
             Err(e) => {
                 if let Err(e_emit) = app_handle.emit_all(
@@ -167,6 +168,7 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
                 ) {
                     log::error!("Failed to emit error status update: {}", e_emit);
                 }
+                state_clone.update_tray_menu().await;
             }
         }
     });
@@ -186,13 +188,15 @@ pub async fn disconnect(app_handle: tauri::AppHandle, state: State<'_, AppState>
     }
 
     state.tor_manager.disconnect().await?;
-
+    
     if let Err(e) = app_handle.emit_all(
         "tor-status-update",
         serde_json::json!({ "status": "DISCONNECTED", "bootstrapProgress": 0, "bootstrapMessage": "", "retryCount": 0, "retryDelay": 0 }),
     ) {
         log::error!("Failed to emit status update: {}", e);
     }
+
+    state.update_tray_menu().await;
 
     Ok(())
 }

--- a/src-tauri/tests/fuzz_commands.rs
+++ b/src-tauri/tests/fuzz_commands.rs
@@ -43,9 +43,11 @@ fn mock_state() -> AppState<MockTorClient> {
         max_log_lines: Arc::new(Mutex::new(1000)),
         memory_usage: Arc::new(Mutex::new(0)),
         circuit_count: Arc::new(Mutex::new(0)),
+        latency_ms: Arc::new(Mutex::new(0)),
         max_memory_mb: 1024,
         max_circuits: 20,
         session: SessionManager::new(std::time::Duration::from_secs(60)),
+        app_handle: Arc::new(Mutex::new(None)),
         tray_warning: Arc::new(Mutex::new(None)),
     }
 }


### PR DESCRIPTION
## Summary
- add status and warning handling to tray menu
- toggle tray items on connect/disconnect events
- expose `clear_tray_warning` and show connection state
- update tests

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml --no-run` *(fails: failed to run custom build command for `glib-sys`)*

------
https://chatgpt.com/codex/tasks/task_e_68694a7f64208333b6e052266cd7abd4