### PR TITLE
Document production deployment steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,36 @@ relevant:
 4. Tag und Branch pushen – der Release-Workflow baut und signiert die Pakete
    automatisch und lädt sie zu GitHub Releases hoch.
 
+## Production Deployment
+
+Stellen Sie für produktive Umgebungen einen erreichbaren Update-Endpunkt bereit,
+damit die Zertifikate laut [CertificateManagement](docs/CertificateManagement.md)
+regelmäßig erneuert werden können. Prüfen Sie `torwell.log` auf Meldungen wie
+`certificate update failed`. Sobald das konfigurierbare Zeilenlimit erreicht
+ist, rotiert die Anwendung die Datei und verschiebt ältere Logs in den Ordner
+`archive`.
+
+Unter Linux empfiehlt sich der Betrieb als systemd‑Service. Eine minimale
+`torwell84.service`‑Datei könnte so aussehen:
+
+```ini
+[Unit]
+Description=Torwell84 Service
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/torwell84/Torwell84
+Restart=always
+User=torwell
+Group=torwell
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Logs lassen sich anschließend mit `journalctl -u torwell84.service` abrufen.
+
 ## Installation
 
 ### Windows Installation

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -40,3 +40,11 @@ die Anwendung die erforderlichen Berechtigungen besitzt und teste die
 Integration mit einem frischen Benutzerkonto, um Berechtigungsprobleme
 auszuschließen.
 
+## Stolperfallen
+
+- Fehlende Systembibliotheken wie `glib-2.0` verhindern einen erfolgreichen `cargo check`.
+- Vergessenes `bun install` führt zu nicht auflösbaren Frontend-Abhängigkeiten.
+- Bei zu vielen Verbindungsversuchen oder Log-Abfragen tritt ein `RateLimited`-Fehler auf.
+- Falsch konfigurierte Zertifikats-URLs melden `certificate update failed` im `torwell.log`.
+- Scheitert die Schlüsselbundintegration, erscheint `keyring access denied` in der Konsole.
+


### PR DESCRIPTION
## Summary
- add production deployment section to README
- list deployment pitfalls in Troubleshooting guide

## Testing
- `bun run check` *(fails: svelte-check found errors)*
- `cargo test` *(fails: missing `glib-2.0` system library)*

------
https://chatgpt.com/codex/tasks/task_e_68694a8414e08333966e428f83d87b3a