### PR TITLE
Implement circuit metrics storage

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -259,7 +259,7 @@ pub async fn get_metrics(state: State<'_, AppState>) -> Result<Metrics> {
     let pid = sysinfo::get_current_pid().map_err(|e| Error::Io(e.to_string()))?;
     sys.refresh_process(pid);
     let mem = sys.process(pid).map(|p| p.memory()).unwrap_or(0);
-    state.update_metrics(mem, circ.count).await;
+    state.update_metrics(mem, circ.count, circ.oldest_age).await;
 
     if mem / 1024 / 1024 > state.max_memory_mb {
         let _ = state

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -70,6 +70,8 @@ pub struct AppState<C: TorClientBehavior = TorClient<PreferredRuntime>> {
     pub memory_usage: Arc<Mutex<u64>>,
     /// Current number of circuits
     pub circuit_count: Arc<Mutex<usize>>,
+    /// Age of the oldest circuit in seconds
+    pub oldest_circuit_age: Arc<Mutex<u64>>,
     /// Last recorded network latency in milliseconds
     pub latency_ms: Arc<Mutex<u64>>,
     /// Maximum memory usage before warning (in MB)
@@ -121,6 +123,7 @@ impl<C: TorClientBehavior> Default for AppState<C> {
             max_log_lines: Arc::new(Mutex::new(max_log_lines)),
             memory_usage: Arc::new(Mutex::new(0)),
             circuit_count: Arc::new(Mutex::new(0)),
+            oldest_circuit_age: Arc::new(Mutex::new(0)),
             latency_ms: Arc::new(Mutex::new(0)),
             max_memory_mb: std::env::var("TORWELL_MAX_MEMORY_MB")
                 .ok()
@@ -177,6 +180,7 @@ impl<C: TorClientBehavior> AppState<C> {
             max_log_lines: Arc::new(Mutex::new(max_log_lines)),
             memory_usage: Arc::new(Mutex::new(0)),
             circuit_count: Arc::new(Mutex::new(0)),
+            oldest_circuit_age: Arc::new(Mutex::new(0)),
             latency_ms: Arc::new(Mutex::new(0)),
             max_memory_mb: std::env::var("TORWELL_MAX_MEMORY_MB")
                 .ok()
@@ -301,9 +305,10 @@ impl<C: TorClientBehavior> AppState<C> {
     }
 
     /// Update stored metrics
-    pub async fn update_metrics(&self, memory: u64, circuits: usize) {
+    pub async fn update_metrics(&self, memory: u64, circuits: usize, oldest_age: u64) {
         *self.memory_usage.lock().await = memory;
         *self.circuit_count.lock().await = circuits;
+        *self.oldest_circuit_age.lock().await = oldest_age;
 
         let memory_mb = memory / 1024 / 1024;
         if memory_mb > self.max_memory_mb {
@@ -338,10 +343,11 @@ impl<C: TorClientBehavior> AppState<C> {
     }
 
     /// Retrieve current metrics
-    pub async fn metrics(&self) -> (u64, usize) {
+    pub async fn metrics(&self) -> (u64, usize, u64) {
         let mem = *self.memory_usage.lock().await;
         let circ = *self.circuit_count.lock().await;
-        (mem, circ)
+        let age = *self.oldest_circuit_age.lock().await;
+        (mem, circ, age)
     }
 
     /// Retrieve current latency
@@ -379,7 +385,7 @@ impl<C: TorClientBehavior> AppState<C> {
                     Err(_) => 0,
                 };
 
-                self.update_metrics(mem, circ.count).await;
+                self.update_metrics(mem, circ.count, circ.oldest_age).await;
                 self.update_latency(latency).await;
 
                 let _ = handle.emit_all(
@@ -387,7 +393,8 @@ impl<C: TorClientBehavior> AppState<C> {
                     serde_json::json!({
                         "memory_bytes": mem,
                         "circuit_count": circ.count,
-                        "latency_ms": latency
+                        "latency_ms": latency,
+                        "oldest_age": circ.oldest_age
                     }),
                 );
             }

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -567,9 +567,10 @@ impl TorManager {
 
         #[cfg(feature = "experimental-api")]
         {
-            // Use new arti-client APIs when compiled with the experimental feature.
-            // These APIs allow retrieving information about currently open circuits
-            // including their creation time.
+            // Use arti-client APIs to retrieve information about currently open
+            // circuits and calculate their age. If the call fails (e.g. due to
+            // lack of support in the underlying implementation) fall back to
+            // returning zeroed metrics.
             use arti_client::client::CircuitInfoExt as _;
 
             if let Ok(circs) = client.circmgr().list_circuits() {
@@ -585,7 +586,6 @@ impl TorManager {
             }
         }
 
-        // Fallback when the arti-client APIs are unavailable.
         Ok(CircuitMetrics {
             count: 0,
             oldest_age: 0,

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -78,9 +78,12 @@ fn mock_state() -> AppState<MockTorClient> {
         max_log_lines: Arc::new(Mutex::new(1000)),
         memory_usage: Arc::new(Mutex::new(0)),
         circuit_count: Arc::new(Mutex::new(0)),
+        oldest_circuit_age: Arc::new(Mutex::new(0)),
+        latency_ms: Arc::new(Mutex::new(0)),
         max_memory_mb: 1024,
         max_circuits: 20,
         session: SessionManager::new(std::time::Duration::from_secs(60)),
+        app_handle: Arc::new(Mutex::new(None)),
         tray_warning: Arc::new(Mutex::new(None)),
     }
 }

--- a/src-tauri/tests/state_tests.rs
+++ b/src-tauri/tests/state_tests.rs
@@ -74,6 +74,7 @@ async fn update_metrics_closes_circuits_on_limit() {
         max_log_lines: Arc::new(Mutex::new(1000)),
         memory_usage: Arc::new(Mutex::new(0)),
         circuit_count: Arc::new(Mutex::new(0)),
+        oldest_circuit_age: Arc::new(Mutex::new(0)),
         latency_ms: Arc::new(Mutex::new(0)),
         max_memory_mb: 1,
         max_circuits: 1,
@@ -82,7 +83,7 @@ async fn update_metrics_closes_circuits_on_limit() {
         tray_warning: Arc::new(Mutex::new(None)),
     };
     let _ = tokio::fs::remove_file("state.log").await;
-    state.update_metrics(2 * 1024 * 1024, 2).await;
+    state.update_metrics(2 * 1024 * 1024, 2, 0).await;
 
     assert!(*flag.lock().unwrap());
     let logs = state.read_logs().await.unwrap();
@@ -105,6 +106,7 @@ async fn tray_warning_on_memory_limit() {
         max_log_lines: Arc::new(Mutex::new(1000)),
         memory_usage: Arc::new(Mutex::new(0)),
         circuit_count: Arc::new(Mutex::new(0)),
+        oldest_circuit_age: Arc::new(Mutex::new(0)),
         latency_ms: Arc::new(Mutex::new(0)),
         max_memory_mb: 1,
         max_circuits: 10,
@@ -113,7 +115,7 @@ async fn tray_warning_on_memory_limit() {
         tray_warning: Arc::new(Mutex::new(None)),
     };
     let _ = tokio::fs::remove_file("mem.log").await;
-    state.update_metrics(2 * 1024 * 1024, 0).await;
+    state.update_metrics(2 * 1024 * 1024, 0, 0).await;
     assert!(state.tray_warning.lock().await.as_ref().unwrap().contains("memory"));
 }
 
@@ -133,6 +135,7 @@ async fn tray_warning_on_circuit_limit() {
         max_log_lines: Arc::new(Mutex::new(1000)),
         memory_usage: Arc::new(Mutex::new(0)),
         circuit_count: Arc::new(Mutex::new(0)),
+        oldest_circuit_age: Arc::new(Mutex::new(0)),
         latency_ms: Arc::new(Mutex::new(0)),
         max_memory_mb: 1024,
         max_circuits: 1,
@@ -141,6 +144,6 @@ async fn tray_warning_on_circuit_limit() {
         tray_warning: Arc::new(Mutex::new(None)),
     };
     let _ = tokio::fs::remove_file("circ.log").await;
-    state.update_metrics(0, 2).await;
+    state.update_metrics(0, 2, 0).await;
     assert!(state.tray_warning.lock().await.as_ref().unwrap().contains("circuit"));
 }

--- a/src/lib/components/MetricsChart.svelte
+++ b/src/lib/components/MetricsChart.svelte
@@ -4,31 +4,50 @@
   const width = 120;
   const height = 40;
 
-  function buildPath(data: MetricPoint[]): string {
+  function buildPath(data: MetricPoint[], field: keyof MetricPoint): string {
     if (data.length === 0) return "";
-    const maxVal = Math.max(...data.map((d) => d.memoryMB), 1);
+    const maxVal = Math.max(...data.map((d) => d[field] as number), 1);
     const step = width / Math.max(data.length - 1, 1);
     let d = `M0 ${height}`;
     data.forEach((pt, idx) => {
       const x = idx * step;
-      const y = height - (pt.memoryMB / maxVal) * height;
+      const y = height - ((pt[field] as number) / maxVal) * height;
       d += ` L${x} ${y}`;
     });
     d += ` L${width} ${height} Z`;
     return d;
   }
 
-  $: pathData = buildPath(metrics);
+  $: memoryPath = buildPath(metrics, "memoryMB");
+  $: circuitPath = buildPath(metrics, "circuitCount");
+  $: agePath = buildPath(metrics, "oldestAge");
 </script>
 
 <svg {width} {height} class="text-green-400">
-  {#if pathData}
+  {#if memoryPath}
     <path
-      d={pathData}
+      d={memoryPath}
       fill="currentColor"
       fill-opacity="0.3"
       stroke="currentColor"
       stroke-width="1"
+    />
+  {/if}
+  {#if circuitPath}
+    <path
+      d={circuitPath}
+      fill="none"
+      stroke="blue"
+      stroke-width="1"
+    />
+  {/if}
+  {#if agePath}
+    <path
+      d={agePath}
+      fill="none"
+      stroke="orange"
+      stroke-width="1"
+      stroke-dasharray="2,2"
     />
   {/if}
 </svg>

--- a/src/lib/stores/torStore.ts
+++ b/src/lib/stores/torStore.ts
@@ -29,6 +29,7 @@ export interface MetricPoint {
   memoryMB: number;
   circuitCount: number;
   latencyMs: number;
+  oldestAge: number;
 }
 
 function createTorStore() {
@@ -56,6 +57,7 @@ function createTorStore() {
       memoryMB: Math.round(event.payload.memory_bytes / 1_000_000),
       circuitCount: event.payload.circuit_count,
       latencyMs: event.payload.latency_ms,
+      oldestAge: event.payload.oldest_age ?? 0,
     };
     update((state) => {
       const metrics = [...state.metrics, point].slice(-MAX_POINTS);


### PR DESCRIPTION
## Summary
- collect circuit metrics when arti exposes circuit listing
- store circuit age in state and send to frontend
- display memory, circuit count, and age history in `MetricsChart`
- adjust tests for updated `AppState`

## Testing
- `cargo test --no-run` *(fails: glib-sys missing)*

------
https://chatgpt.com/codex/tasks/task_e_68694a8130288333b3c63158d514412a