### PR TITLE
Add systemd service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,9 @@ regelmäßig erneuert werden können. Prüfen Sie `torwell.log` auf Meldungen wi
 ist, rotiert die Anwendung die Datei und verschiebt ältere Logs in den Ordner
 `archive`.
 
-Unter Linux empfiehlt sich der Betrieb als systemd‑Service. Eine minimale
-`torwell84.service`‑Datei könnte so aussehen:
+ Unter Linux empfiehlt sich der Betrieb als systemd‑Service. Die vollständige
+ Datei findet sich unter `src-tauri/torwell84.service`. Eine minimale
+ `torwell84.service`‑Datei könnte so aussehen:
 
 ```ini
 [Unit]
@@ -260,6 +261,8 @@ WantedBy=multi-user.target
 ```
 
 Logs lassen sich anschließend mit `journalctl -u torwell84.service` abrufen.
+Weitere Hinweise zur Einrichtung finden sich in
+[docs/ProductionDeployment.md](docs/ProductionDeployment.md).
 
 ## Installation
 

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -1,0 +1,19 @@
+# Production Deployment
+
+Torwell84 can run as a systemd service on Linux systems.
+The repository provides a ready-to-use unit file at
+`src-tauri/torwell84.service`.
+
+## Installation
+
+Copy the file to your systemd directory and enable the service:
+
+```bash
+sudo cp src-tauri/torwell84.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now torwell84.service
+```
+
+The service starts `/opt/torwell84/Torwell84` as the `torwell` user and group
+and restarts automatically on failure. Logs are available with
+`journalctl -u torwell84.service`.

--- a/src-tauri/torwell84.service
+++ b/src-tauri/torwell84.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Torwell84 Service
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/torwell84/Torwell84
+Restart=always
+User=torwell
+Group=torwell
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add sample `torwell84.service`
- document service setup in new ProductionDeployment doc
- reference service file and new doc in README

## Testing
- `bun run check` *(fails: svelte-check found errors)*
- `cargo check` *(fails: glib-2.0 development files missing)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*
- `cargo test` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68695b90ff788333a62bdb2294782135