### PR TITLE
Implement SettingsModal persistence tests

### DIFF
--- a/src/__tests__/SettingsModal.e2e.spec.ts
+++ b/src/__tests__/SettingsModal.e2e.spec.ts
@@ -3,7 +3,33 @@ import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 import 'fake-indexeddb/auto';
 
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
-vi.mock('@tauri-apps/api/tauri', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/tauri', () => {
+  const store = new Map<string, any>();
+  return {
+    invoke: vi.fn((cmd: string, args?: any) => {
+      if (cmd === 'get_secure_key') {
+        return Promise.resolve(store.get('aes-key') ?? null);
+      }
+      if (cmd === 'set_secure_key') {
+        store.set('aes-key', args.value);
+        return Promise.resolve();
+      }
+      if (cmd === 'set_bridges') {
+        store.set('bridges', args.bridges);
+        return Promise.resolve();
+      }
+      if (cmd === 'set_exit_country') {
+        store.set('exitCountry', args.country);
+        return Promise.resolve();
+      }
+      if (cmd === 'set_log_limit') {
+        store.set('logLimit', args.limit);
+        return Promise.resolve();
+      }
+      return Promise.resolve(null);
+    }),
+  };
+});
 
 import SettingsModal from '../lib/components/SettingsModal.svelte';
 import { db } from '../lib/database';
@@ -28,6 +54,7 @@ describe('SettingsModal persistence', () => {
 
   it('saves and reloads settings', async () => {
     const { getByLabelText, getByRole, unmount } = render(SettingsModal, { props: { show: true } });
+    await Promise.resolve();
 
     await fireEvent.click(getByLabelText(BRIDGE));
     await fireEvent.change(getByLabelText('Exit country'), { target: { value: 'DE' } });
@@ -52,6 +79,7 @@ describe('SettingsModal persistence', () => {
 
   it('applies bridges via store and backend', async () => {
   const { getByLabelText, getByRole } = render(SettingsModal, { props: { show: true } });
+  await Promise.resolve();
 
   await fireEvent.click(getByLabelText(BRIDGE));
   await fireEvent.click(getByRole('button', { name: 'Apply bridge selection' }));
@@ -68,4 +96,56 @@ describe('SettingsModal persistence', () => {
   const stored = await db.settings.get(1);
   expect(stored?.bridges).toContain(BRIDGE);
 });
+
+  it('loads and saves bridge selection', async () => {
+    const { getByLabelText, getByRole, unmount } = render(SettingsModal, { props: { show: true } });
+    await Promise.resolve();
+
+    await fireEvent.click(getByLabelText(BRIDGE));
+    await fireEvent.click(getByRole('button', { name: 'Apply bridge selection' }));
+
+    unmount();
+
+    const stored = await db.settings.get(1);
+    expect(stored?.bridges).toEqual([BRIDGE]);
+
+    const { getByLabelText: getAgain } = render(SettingsModal, { props: { show: true } });
+    const bridgeCheckbox = getAgain(BRIDGE) as HTMLInputElement;
+    expect(bridgeCheckbox.checked).toBe(true);
+  });
+
+  it('selects exit country and persists', async () => {
+    const { getByLabelText, getByRole, unmount } = render(SettingsModal, { props: { show: true } });
+    await Promise.resolve();
+
+    await fireEvent.change(getByLabelText('Exit country'), { target: { value: 'DE' } });
+    await fireEvent.click(getByRole('button', { name: 'Save exit country' }));
+
+    unmount();
+
+    const stored = await db.settings.get(1);
+    expect(stored?.exitCountry).toBe('DE');
+
+    const { getByLabelText: get2 } = render(SettingsModal, { props: { show: true } });
+    const select = get2('Exit country') as HTMLSelectElement;
+    expect(select.value).toBe('DE');
+
+    const { invoke } = await import('@tauri-apps/api/tauri');
+    expect(invoke).toHaveBeenCalledWith('set_exit_country', { country: 'DE' });
+  });
+
+  it('calls setLogLimit action', async () => {
+    const { uiStore } = await import('../lib/stores/uiStore');
+    const spy = vi.spyOn(uiStore.actions, 'setLogLimit');
+
+    const { getByLabelText, getByRole } = render(SettingsModal, { props: { show: true } });
+
+    await fireEvent.input(getByLabelText('Maximum log lines'), { target: { value: '200' } });
+    await fireEvent.click(getByRole('button', { name: 'Save log limit' }));
+
+    expect(spy).toHaveBeenCalledWith(200);
+
+    const stored = await db.settings.get(1);
+    expect(stored?.maxLogLines).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- add mocking in SettingsModal tests to mimic backend behavior
- cover saving and reloading bridge selections
- verify exit-country persistence and log-limit actions

## Testing
- `npx vitest run src/__tests__/SettingsModal.e2e.spec.ts` *(fails: Unable to find a label with the text of the bridge)*

------
https://chatgpt.com/codex/tasks/task_e_68695b90131883339e79dccf6f80525b