### PR TITLE
Update certificate URL for production server

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ easily restore the previous UI.
 
 ### Updating Certificates
 The pinned certificate location is configured in `src-tauri/certs/cert_config.json`.
-By default this file points `cert_url` to `https://internal.torwell.local/certs/server.pem` as a
+By default this file points `cert_url` to `https://updates.torwell.com/certs/server.pem` as a
 placeholder. **Provide your own update endpoint for production.** Adjust the value
 or set the environment variables `TORWELL_CERT_URL` or `TORWELL_CERT_PATH` to override the URL and local path at runtime.
 The minimum TLS version can also be configured via the `min_tls_version` field

--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -39,7 +39,7 @@ locations during development.
 ```json
 {
   "cert_path": "src-tauri/certs/server.pem",
-  "cert_url": "https://updates.torwell.com/server.pem",
+  "cert_url": "https://updates.torwell.com/certs/server.pem",
   "fallback_cert_url": null,
   "min_tls_version": "1.2"
 }
@@ -80,7 +80,7 @@ let client = SecureHttpClient::init(
 
 ## Konfiguration
 
-Der Standardwert für `cert_url` verweist auf `https://updates.torwell.com/server.pem` und dient lediglich als Platzhalter.
+Der Standardwert für `cert_url` verweist auf `https://updates.torwell.com/certs/server.pem` und dient lediglich als Platzhalter.
 Für produktive Einsätze muss dieser Wert auf den eigenen Update-Server zeigen.
 Dazu öffnen Sie `src-tauri/certs/cert_config.json` und ersetzen die URL durch den gewünschten Endpunkt.
 Alternativ können Sie beim Aufruf von `SecureHttpClient::init` einen abweichenden Wert übergeben, ohne die Datei zu verändern.
@@ -126,7 +126,7 @@ Neustart der Anwendung erforderlich ist.
 ### Rotation Workflow
 
 1. Lege das neue Zertifikat auf dem Produktionsserver unter
-   `https://updates.torwell.com/server.pem` ab.
+   `https://updates.torwell.com/certs/server.pem` ab.
 2. Beim Start liest `SecureHttpClient` `cert_config.json` ein und
    verwendet `cert_url`, sofern keine Umgebungsvariable gesetzt ist.
    Wird `TORWELL_CERT_URL` definiert, hat dieser Wert Vorrang.
@@ -152,7 +152,7 @@ sicherstellt, dass immer ein gültiges Zertifikat vorliegt.
 
 1. **Quellserver**
    Das frische Zertifikat wird von der unternehmensinternen PKI erzeugt und auf
-   dem Update-Server unter `https://updates.torwell.com/server.pem` abgelegt. Der
+   dem Update-Server unter `https://updates.torwell.com/certs/server.pem` abgelegt. Der
    Pfad ist in `cert_config.json` hinterlegt und kann über
    `TORWELL_CERT_URL` überschrieben werden.
 2. **Zeitplan**

--- a/src-tauri/certs/cert_config.json
+++ b/src-tauri/certs/cert_config.json
@@ -1,6 +1,6 @@
 {
   "cert_path": "src-tauri/certs/server.pem",
-  "cert_url": "https://updates.torwell.com/server.pem",
+  "cert_url": "https://updates.torwell.com/certs/server.pem",
   "fallback_cert_url": null,
   "min_tls_version": "1.2",
   "note": "Production certificate update endpoint"

--- a/src-tauri/src/secure_http.rs
+++ b/src-tauri/src/secure_http.rs
@@ -22,7 +22,7 @@ use tokio::sync::Mutex;
 pub const DEFAULT_CERT_PATH: &str = "src-tauri/certs/server.pem";
 
 /// Default URL for retrieving updated certificates
-pub const DEFAULT_CERT_URL: &str = "https://updates.torwell.com/server.pem";
+pub const DEFAULT_CERT_URL: &str = "https://updates.torwell.com/certs/server.pem";
 
 /// Default location of the certificate configuration file
 pub const DEFAULT_CONFIG_PATH: &str = "src-tauri/certs/cert_config.json";


### PR DESCRIPTION
## Summary
- point `cert_url` to the production update server in `cert_config.json`
- document the new URL in README and CertificateManagement docs
- keep default constant in `secure_http.rs` in sync with the new endpoint

## Testing
- `npm test` *(fails: vitest not found)*
- `cargo test` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68695b8f2d60833381d44390dc3ec533