### PR TITLE
Add external GeoIP database option

### DIFF
--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -210,3 +210,4 @@ und Probleme frühzeitig erkannt werden.
 - Sollte keine Hintergrundaufgabe laufen, kann `schedule_updates` nach dem
   Austausch manuell angestoßen werden, um den neuen PEM-Inhalt sofort
   einzulesen.
+\nSee `GeoIPDatabase.md` for configuring an external GeoIP database.

--- a/docs/GeoIPDatabase.md
+++ b/docs/GeoIPDatabase.md
@@ -1,0 +1,13 @@
+# GeoIP Database Configuration
+
+Torwell84 can use an external GeoIP database instead of the embedded one shipped with `arti`.  The path to the directory containing the `geoip` and `geoip6` files can be specified in `src-tauri/app_config.json`:
+
+```json
+{
+  "max_log_lines": 1000,
+  "geoip_path": "path/to/geoip_dir"
+}
+```
+
+If the path is invalid or omitted, the application falls back to the embedded database.
+You may also override the setting with the `TORWELL_GEOIP_PATH` environment variable.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ async-trait = "0.1"
 once_cell = "1"
 logtest = "2"
 serial_test = "2"
+tempfile = "3"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/app_config.json
+++ b/src-tauri/app_config.json
@@ -1,3 +1,4 @@
 {
   "max_log_lines": 1000
+  ,"geoip_path": null
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -32,6 +32,8 @@ pub const DEFAULT_SESSION_TTL: u64 = 3600;
 struct AppConfig {
     #[serde(default = "default_max_log_lines")]
     max_log_lines: usize,
+    #[serde(default)]
+    geoip_path: Option<String>,
 }
 
 fn default_max_log_lines() -> usize {
@@ -106,14 +108,18 @@ impl<C: TorClientBehavior> Default for AppState<C> {
 
         let cfg = AppConfig::load(DEFAULT_CONFIG_PATH);
         let mut max_log_lines = cfg.max_log_lines;
+        let mut geoip_path = cfg.geoip_path.clone();
         if let Ok(val) = std::env::var("TORWELL_MAX_LOG_LINES") {
             if let Ok(n) = val.parse::<usize>() {
                 max_log_lines = n;
             }
         }
+        if let Ok(p) = std::env::var("TORWELL_GEOIP_PATH") {
+            geoip_path = Some(p);
+        }
 
         Self {
-            tor_manager: Arc::new(TorManager::new()),
+            tor_manager: Arc::new(TorManager::new_with_geoip(geoip_path.clone())),
             http_client: Arc::new(
                 SecureHttpClient::new_default().expect("failed to create http client"),
             ),
@@ -165,14 +171,18 @@ impl<C: TorClientBehavior> AppState<C> {
 
         let cfg = AppConfig::load(DEFAULT_CONFIG_PATH);
         let mut max_log_lines = cfg.max_log_lines;
+        let mut geoip_path = cfg.geoip_path.clone();
         if let Ok(val) = std::env::var("TORWELL_MAX_LOG_LINES") {
             if let Ok(n) = val.parse::<usize>() {
                 max_log_lines = n;
             }
         }
+        if let Ok(p) = std::env::var("TORWELL_GEOIP_PATH") {
+            geoip_path = Some(p);
+        }
 
         AppState {
-            tor_manager: Arc::new(TorManager::new()),
+            tor_manager: Arc::new(TorManager::new_with_geoip(geoip_path.clone())),
             http_client,
             log_file,
             log_lock: Arc::new(Mutex::new(())),


### PR DESCRIPTION
## Summary
- allow specifying a geoip directory in `app_config.json`
- fallback to embedded database when custom path fails
- expose `TorManager::new_with_geoip`
- document GeoIP database configuration

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0.pc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686961728af08333b8a54cf6f9156f75