### PR TITLE
Harmonize TorManager errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,16 @@ Open the `.dmg` file from the releases page and drag **Torwell84** to your Appli
 - **UI Library**: Tailwind CSS with `tailwindcss-glassmorphism`
 
 ### Error States
-The backend emits detailed error messages via the `tor-status-update` event. Possible values include `NotConnected`, `AlreadyConnected`, `Bootstrap`, `NetDir`, `Circuit`, and `Identity`.
+The backend emits structured `Error` variants via the `tor-status-update` event. Common values are:
+
+- `NotConnected` – command requires an active connection
+- `AlreadyConnected` – connection attempt while already connected
+- `ConnectionFailed` – connecting Tor failed with a `step` description
+- `Identity` – changing circuits failed during a specific `step`
+- `NetDir` – network directory lookup failed
+- `Circuit` – circuit creation or inspection failed
+- `RateLimited` – action exceeded its rate limit
+- `Timeout` – operation aborted after the allowed time
 
 ## 📈 Roadmap
 


### PR DESCRIPTION
## Summary
- unify circuit error handling in `tor_manager.rs`
- expand README section about possible backend error variants
- add tests for closing circuits while disconnected and connection rate limiting

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869617132fc8333a708fdfbeb7ae602