### PR TITLE
Add Cloudflare worker deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,11 @@ Im Ordner `cf worker` liegt ein kleines Beispiel für einen HTTPS-Proxy als Clou
 
 1. `bun add -g wrangler`
 2. `wrangler init` ausführen und den Beispielcode als `src/index.js` einbinden
-3. Mit `wrangler deploy` veröffentlichen
+3. `wrangler secret put SECRET_TOKEN` setzen
+4. Mit `wrangler deploy` veröffentlichen
+
+Eine ausführlichere Anleitung findet sich in
+[docs/Todo-fuer-User.md](docs/Todo-fuer-User.md).
 
 
 ## Production Deployment

--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -1,0 +1,30 @@
+# Cloudflare Worker als Proxy
+
+Dieses Dokument beschreibt, wie du den Beispiel‑Worker aus dem Ordner `cf worker` deployen kannst und wie der Proxy anschließend in Torwell84 eingebunden wird.
+
+## Worker deployen
+
+1. Installiere [Wrangler](https://developers.cloudflare.com/workers/wrangler/) einmalig:
+   ```bash
+   bun add -g wrangler
+   ```
+2. Starte ein neues Worker‑Projekt im gewünschten Verzeichnis:
+   ```bash
+   wrangler init
+   ```
+   Ersetze die erzeugte Datei `src/index.js` anschließend durch den Inhalt aus `cf worker/Super-HTTPS-Proxy-CF-Worker-.txt`.
+3. Lege ein geheimes Token an, das der Worker zur Authentifizierung erwartet:
+   ```bash
+   wrangler secret put SECRET_TOKEN
+   ```
+4. Veröffentliche den Worker mit:
+   ```bash
+   wrangler deploy
+   ```
+   Der Worker prüft bei jeder Anfrage, ob der Header `X-Proxy-Token` dem gesetzten `SECRET_TOKEN` entspricht.
+
+## Proxy in Torwell84 einrichten
+
+Trage die URL deines Workers in der Anwendung unter **Settings → Worker List** ein. Alternativ kannst du die Adresse in `src/lib/bridge_presets.json` hinterlegen, damit sie beim ersten Start bereits vorgeschlagen wird.
+
+Nach dem Speichern der Einstellungen werden alle über den Worker geleiteten Verbindungen mit dem gesetzten Token authentifiziert.


### PR DESCRIPTION
## Summary
- document Cloudflare worker setup in `docs/Todo-fuer-User.md`
- mention new guide from README and list required `wrangler` commands

## Testing
- `bun run check` *(fails: svelte-check found errors)*
- `bun run lint:a11y` *(fails: svelte-check found errors)*
- `cargo check` *(fails: missing system library `glib-2.0`)*
- `cargo clippy -- -D warnings` *(fails: component not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68699ae360d4833381db2c4c334e45be