### PR TITLE
Improve accessibility labels and docs

### DIFF
--- a/docs/GlassUI.md
+++ b/docs/GlassUI.md
@@ -17,3 +17,16 @@ Die jeweilige Stufe bestimmt Unschärfe, Hintergrundfarbe und Transparenz. Durch
 Gemäß den Abschnitten zur Barrierefreiheit in `DOCUMENTATION.md` sollten alle interaktiven Elemente aussagekräftige `aria-label` Attribute besitzen und ausreichend Farbkontrast aufweisen. Bei modalen Dialogen wandert der Tastaturfokus auf den Schließ-Button, damit Tastaturnutzer das Fenster direkt schließen können.
 
 Farbwahl und Kontrast müssen dabei den WCAG&nbsp;2.1 AA Richtlinien entsprechen, um eine gute Lesbarkeit zu gewährleisten. Insbesondere bei der Verwendung transparenter Hintergründe sollte darauf geachtet werden, dass Text nicht zu wenig Kontrast zum Hintergrund besitzt.
+
+
+### Kontrastwerte
+
+* Normale Textgrößen sollten ein Verhältnis von **4.5:1** oder höher zum Hintergrund erreichen.
+* Große Schrift (ab 24\u00a0px bzw. fett ab 19\u00a0px) darf ein Verhältnis von **3:1** aufweisen.
+* Zur Prüfung eignen sich Tools wie `npx wcag-contrast` oder Browser-Erweiterungen.
+
+### Keyboard-Navigation
+
+* Die Tab-Reihenfolge folgt der visuellen Darstellung.
+* In Modalen landet der Fokus zunächst auf dem Schließen‑Button und wird anschließend innerhalb des Dialogs gehalten (Fokusfalle).
+* Alle Bedienelemente müssen per Tastatur erreichbar sein und aussagekräftige `aria-label` Attribute besitzen.

--- a/src/__tests__/ActionCard.spec.ts
+++ b/src/__tests__/ActionCard.spec.ts
@@ -25,6 +25,7 @@ describe("ActionCard", () => {
     });
 
     const { getByRole } = render(ActionCard);
+    expect(getByRole("region")).toHaveAttribute("aria-label", "Tor controls");
     expect(
       getByRole("button", { name: /connect to tor/i }),
     ).toBeInTheDocument();

--- a/src/__tests__/FocusTrap.spec.ts
+++ b/src/__tests__/FocusTrap.spec.ts
@@ -17,4 +17,11 @@ describe('Modal focus trapping', () => {
     await fireEvent.keyDown(modal, { key: 'Tab', shiftKey: true });
     expect(document.activeElement).toBe(last);
   });
+
+  it('focuses the close button when opened', async () => {
+    const { getByLabelText } = render(LogsModal, { props: { show: true } });
+    await Promise.resolve();
+    const close = getByLabelText('Close logs');
+    expect(document.activeElement).toBe(close);
+  });
 });

--- a/src/__tests__/IdlePanel.spec.ts
+++ b/src/__tests__/IdlePanel.spec.ts
@@ -12,6 +12,8 @@ describe('IdlePanel', () => {
 
     const bar = getByRole('progressbar');
     expect(bar).toHaveAttribute('aria-valuenow', '30');
+    const region = getByRole('region');
+    expect(region).toHaveAttribute('aria-label', 'Connection progress');
   });
 
   it('shows bootstrap message and retry info', () => {

--- a/src/__tests__/StatusCard.spec.ts
+++ b/src/__tests__/StatusCard.spec.ts
@@ -8,7 +8,7 @@ import { invoke } from '@tauri-apps/api/tauri';
 
 describe('StatusCard', () => {
   it('formats traffic as GB', () => {
-    const { getByText } = render(StatusCard, {
+    const { getByText, getByRole } = render(StatusCard, {
       props: {
         status: 'CONNECTED',
         totalTrafficMB: 1500,
@@ -17,6 +17,7 @@ describe('StatusCard', () => {
     });
 
     expect(getByText('1.5 GB')).toBeInTheDocument();
+    expect(getByRole('region')).toHaveAttribute('aria-label', 'Status information');
   });
 
   it('invokes ping_host when ping button clicked', async () => {

--- a/src/__tests__/TorChain.spec.ts
+++ b/src/__tests__/TorChain.spec.ts
@@ -32,9 +32,10 @@ const nodeData = [
 
 describe('TorChain', () => {
   it('renders node card data only when connected', () => {
-    const { queryByText: queryDisconnected } = render(TorChain, {
+    const { queryByText: queryDisconnected, getByRole } = render(TorChain, {
       props: { isConnected: false, nodeData },
     });
+    expect(getByRole('region')).toHaveAttribute('aria-label', 'Tor chain configuration');
     expect(queryDisconnected('1.1.1.1')).not.toBeInTheDocument();
 
     const { getByText } = render(TorChain, {

--- a/src/lib/components/ActionCard.svelte
+++ b/src/lib/components/ActionCard.svelte
@@ -55,7 +55,7 @@
 
 </script>
 
-<div class="glass-md rounded-xl p-6" tabindex="0" role="region">
+<div class="glass-md rounded-xl p-6" tabindex="0" role="region" aria-label="Tor controls">
 	<!-- Error Message -->
 {#if $torStore.errorMessage}
                 <div class="mb-4 p-3 bg-red-900/30 border border-red-700/50 text-red-300 rounded-lg flex items-center gap-2" role="alert" aria-live="assertive">

--- a/src/lib/components/ErrorOverlay.svelte
+++ b/src/lib/components/ErrorOverlay.svelte
@@ -8,9 +8,9 @@ onDestroy(unsub);
 </script>
 
 {#if error}
-  <div class="fixed inset-0 bg-black/70 flex items-center justify-center z-50" role="alertdialog" aria-modal="true">
+  <div class="fixed inset-0 bg-black/70 flex items-center justify-center z-50" role="alertdialog" aria-modal="true" aria-labelledby="error-overlay-title">
     <div class="glass-sm p-4 rounded max-w-md">
-      <p class="font-semibold mb-2">An unexpected error occurred.</p>
+      <p id="error-overlay-title" class="font-semibold mb-2">An unexpected error occurred.</p>
       <pre class="text-xs mb-4">{error.message}</pre>
       <button class="px-3 py-1 bg-black rounded" on:click={() => errorStore.set(null)} aria-label="Dismiss error">Close</button>
     </div>

--- a/src/lib/components/IdlePanel.svelte
+++ b/src/lib/components/IdlePanel.svelte
@@ -18,7 +18,7 @@
 	}
 </script>
 
-<div class="glass-md rounded-xl p-6" tabindex="0" role="region">
+<div class="glass-md rounded-xl p-6" tabindex="0" role="region" aria-label="Connection progress">
 	<div class="flex flex-col items-center gap-3">
 		<!-- Progress Bar -->
                 <div

--- a/src/lib/components/MetricsChart.svelte
+++ b/src/lib/components/MetricsChart.svelte
@@ -23,7 +23,7 @@
   $: agePath = buildPath(metrics, "oldestAge");
 </script>
 
-<svg {width} {height} class="text-green-400">
+<svg {width} {height} class="text-green-400" role="img" aria-label="Tor metrics chart">
   {#if memoryPath}
     <path
       d={memoryPath}

--- a/src/lib/components/SecurityBanner.svelte
+++ b/src/lib/components/SecurityBanner.svelte
@@ -8,7 +8,7 @@
 </script>
 
 {#if $torStore.securityWarning}
-<div class="glass-sm p-2 rounded-lg mb-3 flex items-center justify-between" role="alert" tabindex="0">
+<div class="glass-sm p-2 rounded-lg mb-3 flex items-center justify-between" role="alert" tabindex="0" aria-label="Security warning">
   <span class="text-sm">{$torStore.securityWarning}</span>
   <button on:click={dismiss} aria-label="Dismiss warning" class="ml-2">
     <X size={14} />

--- a/src/lib/components/StatusCard.svelte
+++ b/src/lib/components/StatusCard.svelte
@@ -45,7 +45,7 @@
 </script>
 
 <!-- Status Card -->
-<div class="glass-md rounded-xl p-6" tabindex="0" role="region">
+<div class="glass-md rounded-xl p-6" tabindex="0" role="region" aria-label="Status information">
   <div class="flex items-center justify-between gap-6">
     <!-- Status Section -->
     <div class="flex items-center gap-4">

--- a/src/lib/components/TorChain.svelte
+++ b/src/lib/components/TorChain.svelte
@@ -69,7 +69,7 @@
 	}
 </script>
 
-<div class="glass-md rounded-xl p-6" tabindex="0" role="region">
+<div class="glass-md rounded-xl p-6" tabindex="0" role="region" aria-label="Tor chain configuration">
 	<!-- Single Row with Title, Dropdowns and Active Switch -->
 	<div class="grid grid-cols-5 gap-4 mb-4 items-center h-8">
 		<!-- Tor Chain Title -->


### PR DESCRIPTION
## Summary
- add missing ARIA labels for main components
- document colour contrast guidance and keyboard navigation
- extend focus trap test and add label checks

## Testing
- `npm test` *(fails: 11 failed, 16 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68699adcdc908333aeafdfd1edb92dd3