### PR TITLE
Improve logging with error context

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -116,6 +116,7 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
                             .add_log(
                                 Level::Warn,
                                 format!("connection attempt {} failed: {}", attempt, err_str),
+                                None,
                             )
                             .await;
                     });
@@ -274,6 +275,7 @@ pub async fn get_metrics(state: State<'_, AppState>) -> Result<Metrics> {
                     mem / 1024 / 1024,
                     state.max_memory_mb
                 ),
+                None,
             )
             .await;
     }
@@ -286,6 +288,7 @@ pub async fn get_metrics(state: State<'_, AppState>) -> Result<Metrics> {
                     "circuit count {} exceeds limit {}",
                     circ.count, state.max_circuits
                 ),
+                None,
             )
             .await;
     }
@@ -314,9 +317,11 @@ pub async fn get_logs(state: State<'_, AppState>, token: String) -> Result<Vec<L
     track_call("get_logs").await;
     check_api_rate()?;
     if !state.validate_session(&token).await {
+        log::error!("get_logs: invalid token");
         return Err(Error::InvalidToken);
     }
     if LOG_LIMITER.check().is_err() {
+        log::error!("get_logs: rate limit exceeded");
         return Err(Error::RateLimited("get_logs".into()));
     }
     state.read_logs().await
@@ -327,6 +332,7 @@ pub async fn clear_logs(state: State<'_, AppState>, token: String) -> Result<()>
     track_call("clear_logs").await;
     check_api_rate()?;
     if !state.validate_session(&token).await {
+        log::error!("clear_logs: invalid token");
         return Err(Error::InvalidToken);
     }
     state.clear_log_file().await
@@ -337,6 +343,7 @@ pub async fn get_log_file_path(state: State<'_, AppState>, token: String) -> Res
     track_call("get_log_file_path").await;
     check_api_rate()?;
     if !state.validate_session(&token).await {
+        log::error!("get_log_file_path: invalid token");
         return Err(Error::InvalidToken);
     }
     Ok(state.log_file_path())
@@ -358,10 +365,12 @@ pub async fn ping_host(
     track_call("ping_host").await;
     check_api_rate()?;
     if !state.validate_session(&token).await {
+        log::error!("ping_host: invalid token");
         return Err(Error::InvalidToken);
     }
     let host = host.unwrap_or_else(|| "google.com".to_string());
     if !HOST_RE.is_match(&host) {
+        log::error!("ping_host: invalid host '{}'", host);
         return Err(Error::Io("invalid host".into()));
     }
     let count = count.unwrap_or(5).min(MAX_PING_COUNT);
@@ -375,6 +384,7 @@ pub async fn get_secure_key(state: State<'_, AppState>, token: String) -> Result
     track_call("get_secure_key").await;
     check_api_rate()?;
     if !state.validate_session(&token).await {
+        log::error!("get_secure_key: invalid token");
         return Err(Error::InvalidToken);
     }
     let entry = keyring::Entry::new("torwell84", "aes-key")
@@ -391,6 +401,7 @@ pub async fn set_secure_key(state: State<'_, AppState>, token: String, value: St
     track_call("set_secure_key").await;
     check_api_rate()?;
     if !state.validate_session(&token).await {
+        log::error!("set_secure_key: invalid token");
         return Err(Error::InvalidToken);
     }
     let entry = keyring::Entry::new("torwell84", "aes-key")

--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -261,21 +261,28 @@ impl<C: TorClientBehavior> TorManager<C> {
         P: FnMut(u8, String) + Send,
     {
         if self.is_connected().await {
+            log::error!("connect_once: already connected");
             return Err(Error::AlreadyConnected);
         }
         progress(0, "starting".into());
         let config = self
             .build_config()
             .await
-            .map_err(|e| Error::ConnectionFailed {
-                step: "build_config".into(),
-                source: e.to_string(),
+            .map_err(|e| {
+                log::error!("connect_once: build_config failed: {}", e);
+                Error::ConnectionFailed {
+                    step: "build_config".into(),
+                    source: e.to_string(),
+                }
             })?;
         let tor_client = C::create_bootstrapped_with_progress(config, progress)
             .await
-            .map_err(|e| Error::ConnectionFailed {
-                step: "bootstrap".into(),
-                source: e,
+            .map_err(|e| {
+                log::error!("connect_once: bootstrap failed: {}", e);
+                Error::ConnectionFailed {
+                    step: "bootstrap".into(),
+                    source: e,
+                }
             })?;
         *self.client.lock().await = Some(tor_client);
         Ok(())
@@ -297,6 +304,7 @@ impl<C: TorClientBehavior> TorManager<C> {
         P: FnMut(u8, String) + Send,
     {
         if self.connect_limiter.check().is_err() {
+            log::error!("connect_with_backoff: rate limit exceeded");
             return Err(Error::RateLimited("connect".into()));
         }
         let start = std::time::Instant::now();
@@ -304,6 +312,7 @@ impl<C: TorClientBehavior> TorManager<C> {
         let mut delay = INITIAL_BACKOFF;
         loop {
             if start.elapsed() >= max_total_time {
+                log::error!("connect_with_backoff: timeout after {:?}", max_total_time);
                 return Err(Error::Timeout);
             }
             match self.connect_once(&mut on_progress).await {
@@ -312,12 +321,18 @@ impl<C: TorClientBehavior> TorManager<C> {
                     attempt += 1;
                     on_retry(attempt, delay, &e);
                     if attempt > max_retries {
+                        log::error!(
+                            "connect_with_backoff: retries exceeded ({} attempts) - {}",
+                            attempt,
+                            e
+                        );
                         return Err(Error::RetriesExceeded {
                             attempts: attempt,
                             error: e.to_string(),
                         });
                     }
                     if start.elapsed() + delay > max_total_time {
+                        log::error!("connect_with_backoff: total timeout reached");
                         return Err(Error::Timeout);
                     }
                     tokio::time::sleep(delay).await;
@@ -330,6 +345,7 @@ impl<C: TorClientBehavior> TorManager<C> {
     pub async fn disconnect(&self) -> Result<()> {
         let mut client_guard = self.client.lock().await;
         if client_guard.take().is_none() {
+            log::error!("disconnect: not connected");
             return Err(Error::NotConnected);
         }
         // Client is dropped here, which handles shutdown.
@@ -338,6 +354,7 @@ impl<C: TorClientBehavior> TorManager<C> {
 
     pub(crate) async fn lookup_country_code(&self, ip: &str) -> Result<String> {
         if ip.contains('?') {
+            log::error!("lookup_country_code: invalid address {ip}");
             return Err(Error::Lookup(format!("invalid address: {ip}")));
         }
 
@@ -353,12 +370,16 @@ impl<C: TorClientBehavior> TorManager<C> {
 
         let ip_addr = addr
             .parse::<IpAddr>()
-            .map_err(|_| Error::Lookup(format!("invalid address: {}", addr)))?;
+            .map_err(|_| {
+                log::error!("lookup_country_code: invalid address parsed {addr}");
+                Error::Lookup(format!("invalid address: {}", addr))
+            })?;
         if let Some(cc) = self.geoip_db.lookup_country_code(ip_addr) {
             let code = cc.as_ref().to_string();
             cache.insert(ip.to_string(), code.clone());
             Ok(code)
         } else {
+            log::error!("lookup_country_code: country not found for {}", addr);
             Err(Error::Lookup(format!("country not found for {}", addr)))
         }
     }
@@ -366,7 +387,10 @@ impl<C: TorClientBehavior> TorManager<C> {
     pub async fn set_exit_country(&self, country: Option<String>) -> Result<()> {
         let mut guard = self.exit_country.lock().await;
         if let Some(cc) = country {
-            let code = CountryCode::new(&cc).map_err(|e| Error::Tor(e.to_string()))?;
+            let code = CountryCode::new(&cc).map_err(|e| {
+                log::error!("set_exit_country: invalid code {} - {}", cc, e);
+                Error::Tor(e.to_string())
+            })?;
             *guard = Some(code);
         } else {
             *guard = None;
@@ -400,20 +424,33 @@ impl<C: TorClientBehavior> TorManager<C> {
 
     pub async fn new_identity(&self) -> Result<()> {
         let client_guard = self.client.lock().await;
-        let client = client_guard.as_ref().ok_or(Error::NotConnected)?;
+        let client = client_guard.as_ref().ok_or_else(|| {
+            log::error!("new_identity: not connected");
+            Error::NotConnected
+        })?;
 
         if self.circuit_limiter.check().is_err() {
+            log::error!("new_identity: rate limit exceeded");
             return Err(Error::RateLimited("new_identity".into()));
         }
 
         // Force new configuration and circuits
-        let config = self.build_config().await.map_err(|e| Error::Identity {
-            step: "build_config".into(),
-            source: e.to_string(),
-        })?;
-        client.reconfigure(&config).map_err(|e| Error::Identity {
-            step: "reconfigure".into(),
-            source: e,
+        let config = self
+            .build_config()
+            .await
+            .map_err(|e| {
+                log::error!("new_identity: build_config failed: {}", e);
+                Error::Identity {
+                    step: "build_config".into(),
+                    source: e.to_string(),
+                }
+            })?;
+        client.reconfigure(&config).map_err(|e| {
+            log::error!("new_identity: reconfigure failed: {}", e);
+            Error::Identity {
+                step: "reconfigure".into(),
+                source: e,
+            }
         })?;
         client.retire_all_circs();
 
@@ -421,9 +458,12 @@ impl<C: TorClientBehavior> TorManager<C> {
         client
             .build_new_circuit()
             .await
-            .map_err(|e| Error::Identity {
-                step: "build_circuit".into(),
-                source: e,
+            .map_err(|e| {
+                log::error!("new_identity: build_circuit failed: {}", e);
+                Error::Identity {
+                    step: "build_circuit".into(),
+                    source: e,
+                }
             })?;
 
         Ok(())
@@ -432,7 +472,10 @@ impl<C: TorClientBehavior> TorManager<C> {
     /// Close all currently open circuits without building a new one.
     pub async fn close_all_circuits(&self) -> Result<()> {
         let client_guard = self.client.lock().await;
-        let client = client_guard.as_ref().ok_or(Error::NotConnected)?;
+        let client = client_guard.as_ref().ok_or_else(|| {
+            log::error!("close_all_circuits: not connected");
+            Error::NotConnected
+        })?;
         client.retire_all_circs();
         Ok(())
     }
@@ -441,12 +484,20 @@ impl<C: TorClientBehavior> TorManager<C> {
 impl TorManager {
     pub async fn get_active_circuit(&self) -> Result<Vec<RelayInfo>> {
         let client_guard = self.client.lock().await;
-        let client = client_guard.as_ref().ok_or(Error::NotConnected)?;
+        let client = client_guard.as_ref().ok_or_else(|| {
+            log::error!("traffic_stats: not connected");
+            Error::NotConnected
+        })?;
 
         let netdir = client
             .dirmgr()
             .netdir(Timeliness::Timely)
             .map_err(|e| Error::NetDir(e.to_string()))?;
+        let exit_pref = self.exit_country.lock().await.clone();
+        log::info!(
+            "building active circuit with exit {:?}",
+            exit_pref.as_ref().map(|c| c.to_string())
+        );
         let circuit = client
             .circmgr()
             .get_or_launch_exit(
@@ -456,7 +507,14 @@ impl TorManager {
                 None,
             )
             .await
-            .map_err(|e| Error::Circuit(e.to_string()))?;
+            .map_err(|e| {
+                log::error!(
+                    "get_active_circuit: failed to build circuit with exit {:?}: {}",
+                    exit_pref.as_ref().map(|c| c.to_string()),
+                    e
+                );
+                Error::Circuit(e.to_string())
+            })?;
 
         let hops: Vec<_> = circuit
             .path_ref()
@@ -500,7 +558,10 @@ impl TorManager {
 
     pub async fn get_isolated_circuit(&self, domain: String) -> Result<Vec<RelayInfo>> {
         let client_guard = self.client.lock().await;
-        let client = client_guard.as_ref().ok_or(Error::NotConnected)?;
+        let client = client_guard.as_ref().ok_or_else(|| {
+            log::error!("circuit_metrics: not connected");
+            Error::NotConnected
+        })?;
 
         let mut tokens = self.isolation_tokens.lock().await;
         let entry = tokens.entry(domain).or_default();
@@ -526,11 +587,25 @@ impl TorManager {
             })
         };
 
+        let exit_pref = prefs.as_ref().and_then(|p| p.exit_country());
+        log::info!(
+            "building isolated circuit for domain {} with exit {:?}",
+            domain,
+            exit_pref
+        );
         let circuit = client
             .circmgr()
             .get_or_launch_exit((&*netdir).into(), &[], isolation, prefs)
             .await
-            .map_err(|e| Error::Circuit(e.to_string()))?;
+            .map_err(|e| {
+                log::error!(
+                    "get_isolated_circuit: failed for domain {} with exit {:?}: {}",
+                    domain,
+                    exit_pref,
+                    e
+                );
+                Error::Circuit(e.to_string())
+            })?;
 
         let hops: Vec<_> = circuit
             .path_ref()
@@ -575,7 +650,10 @@ impl TorManager {
     /// Return the total number of bytes sent and received through the Tor client.
     pub async fn traffic_stats(&self) -> Result<TrafficStats> {
         let client_guard = self.client.lock().await;
-        let client = client_guard.as_ref().ok_or(Error::NotConnected)?;
+        let client = client_guard.as_ref().ok_or_else(|| {
+            log::error!("get_active_circuit: not connected");
+            Error::NotConnected
+        })?;
 
         let stats = client.traffic_stats();
         Ok(TrafficStats {
@@ -587,7 +665,10 @@ impl TorManager {
     /// Return number of active circuits and age of the oldest one in seconds.
     pub async fn circuit_metrics(&self) -> Result<CircuitMetrics> {
         let client_guard = self.client.lock().await;
-        let client = client_guard.as_ref().ok_or(Error::NotConnected)?;
+        let client = client_guard.as_ref().ok_or_else(|| {
+            log::error!("get_isolated_circuit: not connected");
+            Error::NotConnected
+        })?;
 
         #[cfg(feature = "experimental-api")]
         {

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -7,6 +7,7 @@ use tauri::Manager;
 use tokio::sync::Mutex;
 
 use log::Level;
+use regex::Regex;
 use torwell84::commands;
 use torwell84::error::Error;
 use torwell84::secure_http::SecureHttpClient;
@@ -190,12 +191,13 @@ async fn command_log_retrieval() {
     let _ = tokio::fs::remove_file(&state.log_file).await;
     app.manage(state);
     let state = app.state::<AppState<MockTorClient>>();
-    state.add_log(Level::Info, "line1".into()).await.unwrap();
-    state.add_log(Level::Warn, "line2".into()).await.unwrap();
+    state.add_log(Level::Info, "line1".into(), None).await.unwrap();
+    state.add_log(Level::Warn, "line2".into(), None).await.unwrap();
     let logs = commands::get_logs(state).await.unwrap();
     assert_eq!(logs.len(), 2);
-    assert_eq!(logs[0].message, "line1");
+    assert!(Regex::new("line1").unwrap().is_match(&logs[0].message));
     assert_eq!(logs[0].level, "INFO");
+    assert!(Regex::new("line2").unwrap().is_match(&logs[1].message));
     assert_eq!(logs[1].level, "WARN");
     commands::clear_logs(state).await.unwrap();
     let logs = commands::get_logs(state).await.unwrap();
@@ -213,14 +215,14 @@ async fn command_set_log_limit_trims_logs() {
     let state = app.state::<AppState<MockTorClient>>();
 
     commands::set_log_limit(state, 2).await.unwrap();
-    state.add_log(Level::Info, "one".into()).await.unwrap();
-    state.add_log(Level::Info, "two".into()).await.unwrap();
-    state.add_log(Level::Info, "three".into()).await.unwrap();
+    state.add_log(Level::Info, "one".into(), None).await.unwrap();
+    state.add_log(Level::Info, "two".into(), None).await.unwrap();
+    state.add_log(Level::Info, "three".into(), None).await.unwrap();
 
     let logs = commands::get_logs(state).await.unwrap();
     assert_eq!(logs.len(), 2);
-    assert_eq!(logs[0].message, "two");
-    assert_eq!(logs[1].message, "three");
+    assert!(Regex::new("two").unwrap().is_match(&logs[0].message));
+    assert!(Regex::new("three").unwrap().is_match(&logs[1].message));
 }
 
 #[tokio::test]

--- a/src-tauri/tests/state_tests.rs
+++ b/src-tauri/tests/state_tests.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 use tokio::sync::Mutex;
 use log::Level;
+use regex::Regex;
 
 use torwell84::secure_http::SecureHttpClient;
 use torwell84::session::SessionManager;
@@ -178,7 +179,7 @@ async fn log_rotation_creates_archive() {
 
     for i in 0..3 {
         state
-            .add_log(Level::Info, format!("line{}", i))
+            .add_log(Level::Info, format!("line{}", i), None)
             .await
             .unwrap();
     }
@@ -193,6 +194,6 @@ async fn log_rotation_creates_archive() {
 
     let logs = state.read_logs().await.unwrap();
     assert_eq!(logs.len(), 2);
-    assert!(logs[0].message.contains("line1"));
-    assert!(logs[1].message.contains("line2"));
+    assert!(Regex::new("line1").unwrap().is_match(&logs[0].message));
+    assert!(Regex::new("line2").unwrap().is_match(&logs[1].message));
 }


### PR DESCRIPTION
## Summary
- expand `LogEntry` to store optional stack traces
- log failures in `TorManager` and `commands` with extra context
- keep circuit exit info when building circuits
- adapt log API and update tests with regex checks

## Testing
- `cargo test --all` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68699ad6e2048333ab8e0e0e477c7aac