### PR TITLE
Add circuit build metrics

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -131,6 +131,7 @@ pub fn run() {
             commands::set_bridges,
             commands::get_traffic_stats,
             commands::get_metrics,
+            commands::get_circuit_build_stats,
             commands::get_logs,
             commands::clear_logs,
             commands::get_log_file_path,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -404,6 +404,8 @@ impl<C: TorClientBehavior> AppState<C> {
                     Err(_) => 0,
                 };
 
+                let build = self.tor_manager.circuit_build_metrics().await;
+
                 self.update_metrics(mem, circ.count, circ.oldest_age).await;
                 self.update_latency(latency).await;
 
@@ -413,7 +415,9 @@ impl<C: TorClientBehavior> AppState<C> {
                         "memory_bytes": mem,
                         "circuit_count": circ.count,
                         "latency_ms": latency,
-                        "oldest_age": circ.oldest_age
+                        "oldest_age": circ.oldest_age,
+                        "build_ms": build.build_ms,
+                        "build_failures": build.failures
                     }),
                 );
             }

--- a/src-tauri/tests/tor_manager_metrics_tests.rs
+++ b/src-tauri/tests/tor_manager_metrics_tests.rs
@@ -109,3 +109,23 @@ async fn circuit_metrics_connected() {
     assert_eq!(metrics.count, 0);
     assert_eq!(metrics.oldest_age, 0);
 }
+
+#[tokio::test]
+async fn circuit_build_metrics_initial() {
+    let manager: TorManager<MockMetricsClient> = TorManager::new();
+    let m = manager.circuit_build_metrics().await;
+    assert_eq!(m.build_ms, 0);
+    assert_eq!(m.failures, 0);
+}
+
+#[tokio::test]
+async fn circuit_build_metrics_updated_on_identity() {
+    MockMetricsClient::push_client(MockMetricsClient::new(0, 0));
+    let manager: TorManager<MockMetricsClient> = TorManager::new();
+    manager.connect().await.unwrap();
+    manager.new_identity().await.unwrap();
+    let m = manager.circuit_build_metrics().await;
+    assert!(m.build_ms > 0);
+    // no failures expected
+    assert_eq!(m.failures, 0);
+}

--- a/src/__tests__/MetricsChart.spec.ts
+++ b/src/__tests__/MetricsChart.spec.ts
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/svelte';
+import MetricsChart from '../lib/components/MetricsChart.svelte';
+
+describe('MetricsChart', () => {
+  it('renders build time path', () => {
+    const metrics = [
+      { time: 0, memoryMB: 1, circuitCount: 1, latencyMs: 1, oldestAge: 1, buildMs: 5, buildFailures: 0 }
+    ];
+    const { container } = render(MetricsChart, { props: { metrics } });
+    const path = container.querySelector('path[stroke="purple"]');
+    expect(path).toBeTruthy();
+  });
+});

--- a/src/lib/components/MetricsChart.svelte
+++ b/src/lib/components/MetricsChart.svelte
@@ -21,6 +21,7 @@
   $: memoryPath = buildPath(metrics, "memoryMB");
   $: circuitPath = buildPath(metrics, "circuitCount");
   $: agePath = buildPath(metrics, "oldestAge");
+  $: buildPathMs = buildPath(metrics, "buildMs");
 </script>
 
 <svg {width} {height} class="text-green-400">
@@ -48,6 +49,15 @@
       stroke="orange"
       stroke-width="1"
       stroke-dasharray="2,2"
+    />
+  {/if}
+  {#if buildPathMs}
+    <path
+      d={buildPathMs}
+      fill="none"
+      stroke="purple"
+      stroke-width="1"
+      stroke-dasharray="4,2"
     />
   {/if}
 </svg>

--- a/src/lib/stores/torStore.ts
+++ b/src/lib/stores/torStore.ts
@@ -22,6 +22,8 @@ export interface TorState {
   circuitCount: number;
   pingMs: number | undefined;
   metrics: MetricPoint[];
+  buildMs: number;
+  buildFailures: number;
 }
 
 export interface MetricPoint {
@@ -30,6 +32,8 @@ export interface MetricPoint {
   circuitCount: number;
   latencyMs: number;
   oldestAge: number;
+  buildMs: number;
+  buildFailures: number;
 }
 
 function createTorStore() {
@@ -45,6 +49,8 @@ function createTorStore() {
     circuitCount: 0,
     pingMs: undefined,
     metrics: [],
+    buildMs: 0,
+    buildFailures: 0,
   };
 
   const { subscribe, update, set } = writable<TorState>(initialState);
@@ -58,6 +64,8 @@ function createTorStore() {
       circuitCount: event.payload.circuit_count,
       latencyMs: event.payload.latency_ms,
       oldestAge: event.payload.oldest_age ?? 0,
+      buildMs: event.payload.build_ms ?? 0,
+      buildFailures: event.payload.build_failures ?? 0,
     };
     update((state) => {
       const metrics = [...state.metrics, point].slice(-MAX_POINTS);
@@ -67,6 +75,8 @@ function createTorStore() {
         circuitCount: point.circuitCount,
         pingMs: point.latencyMs,
         metrics,
+        buildMs: point.buildMs,
+        buildFailures: point.buildFailures,
       };
     });
   });
@@ -112,6 +122,8 @@ function createTorStore() {
         circuitCount: 0,
         pingMs: undefined,
         metrics: [],
+        buildMs: 0,
+        buildFailures: 0,
       }));
     }
   });


### PR DESCRIPTION
## Summary
- collect Tor circuit build metrics on backend
- expose metrics via new Tauri command
- emit new fields from metrics task
- track metrics in torStore and chart component
- add unit tests for metrics and chart

## Testing
- `npx --yes vitest run` *(fails: cannot find @sveltejs/kit)*
- `cargo test --quiet` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_68699ad55e848333bcff35f06432b543