### PR TITLE
Refine TorManager error diagnostics

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, Result};
+use crate::icmp;
 use crate::state::{AppState, LogEntry};
 use crate::tor_manager::BridgePreset;
 use governor::{
@@ -6,10 +7,10 @@ use governor::{
     state::{InMemoryState, NotKeyed},
     Quota, RateLimiter,
 };
+use keyring;
 use log::Level;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use keyring;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::num::NonZeroU32;
@@ -17,7 +18,6 @@ use std::time::Duration;
 use std::time::Instant;
 use sysinfo::{PidExt, System, SystemExt};
 use tauri::{Manager, State};
-use crate::icmp;
 use tokio::sync::Mutex;
 
 /// Total bytes sent and received through Tor.
@@ -121,13 +121,18 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
                             )
                             .await;
                     });
+                    let step = match err {
+                        Error::ConnectionFailed { step, .. } | Error::Identity { step, .. } => step,
+                        _ => "",
+                    };
                     let _ = app_handle.emit_all(
                         "tor-status-update",
                         serde_json::json!({
                             "status": "RETRYING",
                             "retryCount": attempt,
                             "retryDelay": delay.as_secs(),
-                            "errorMessage": err_str
+                            "errorMessage": err_str,
+                            "errorStep": step
                         }),
                     );
                 },
@@ -159,11 +164,18 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
                 state_clone.update_tray_menu().await;
             }
             Err(e) => {
+                let step = match &e {
+                    Error::ConnectionFailed { step, .. } | Error::Identity { step, .. } => {
+                        step.as_str()
+                    }
+                    _ => "",
+                };
                 if let Err(e_emit) = app_handle.emit_all(
                     "tor-status-update",
                     serde_json::json!({
                         "status": "ERROR",
                         "errorMessage": e.to_string(),
+                        "errorStep": step,
                         "bootstrapMessage": "",
                         "retryCount": 0, "retryDelay": 0
                     }),
@@ -190,7 +202,7 @@ pub async fn disconnect(app_handle: tauri::AppHandle, state: State<'_, AppState>
     }
 
     state.tor_manager.disconnect().await?;
-    
+
     if let Err(e) = app_handle.emit_all(
         "tor-status-update",
         serde_json::json!({ "status": "DISCONNECTED", "bootstrapProgress": 0, "bootstrapMessage": "", "retryCount": 0, "retryDelay": 0 }),
@@ -311,7 +323,7 @@ pub async fn new_identity(app_handle: tauri::AppHandle, state: State<'_, AppStat
     track_call("new_identity").await;
     check_api_rate()?;
     state.tor_manager.new_identity().await?; // potential metric: measure time to build new circuit
-    // Emit event to update frontend
+                                             // Emit event to update frontend
     app_handle.emit_all(
         "tor-status-update",
         serde_json::json!({ "status": "NEW_IDENTITY" }),
@@ -393,8 +405,8 @@ pub async fn get_secure_key(state: State<'_, AppState>, token: String) -> Result
         log::error!("get_secure_key: invalid token");
         return Err(Error::InvalidToken);
     }
-    let entry = keyring::Entry::new("torwell84", "aes-key")
-        .map_err(|e| Error::Io(e.to_string()))?;
+    let entry =
+        keyring::Entry::new("torwell84", "aes-key").map_err(|e| Error::Io(e.to_string()))?;
     match entry.get_password() {
         Ok(v) => Ok(Some(v)),
         Err(keyring::Error::NoEntry) => Ok(None),
@@ -403,14 +415,20 @@ pub async fn get_secure_key(state: State<'_, AppState>, token: String) -> Result
 }
 
 #[tauri::command]
-pub async fn set_secure_key(state: State<'_, AppState>, token: String, value: String) -> Result<()> {
+pub async fn set_secure_key(
+    state: State<'_, AppState>,
+    token: String,
+    value: String,
+) -> Result<()> {
     track_call("set_secure_key").await;
     check_api_rate()?;
     if !state.validate_session(&token).await {
         log::error!("set_secure_key: invalid token");
         return Err(Error::InvalidToken);
     }
-    let entry = keyring::Entry::new("torwell84", "aes-key")
-        .map_err(|e| Error::Io(e.to_string()))?;
-    entry.set_password(&value).map_err(|e| Error::Io(e.to_string()))
+    let entry =
+        keyring::Entry::new("torwell84", "aes-key").map_err(|e| Error::Io(e.to_string()))?;
+    entry
+        .set_password(&value)
+        .map_err(|e| Error::Io(e.to_string()))
 }

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -191,8 +191,14 @@ async fn command_log_retrieval() {
     let _ = tokio::fs::remove_file(&state.log_file).await;
     app.manage(state);
     let state = app.state::<AppState<MockTorClient>>();
-    state.add_log(Level::Info, "line1".into(), None).await.unwrap();
-    state.add_log(Level::Warn, "line2".into(), None).await.unwrap();
+    state
+        .add_log(Level::Info, "line1".into(), None)
+        .await
+        .unwrap();
+    state
+        .add_log(Level::Warn, "line2".into(), None)
+        .await
+        .unwrap();
     let logs = commands::get_logs(state).await.unwrap();
     assert_eq!(logs.len(), 2);
     assert!(Regex::new("line1").unwrap().is_match(&logs[0].message));
@@ -215,9 +221,18 @@ async fn command_set_log_limit_trims_logs() {
     let state = app.state::<AppState<MockTorClient>>();
 
     commands::set_log_limit(state, 2).await.unwrap();
-    state.add_log(Level::Info, "one".into(), None).await.unwrap();
-    state.add_log(Level::Info, "two".into(), None).await.unwrap();
-    state.add_log(Level::Info, "three".into(), None).await.unwrap();
+    state
+        .add_log(Level::Info, "one".into(), None)
+        .await
+        .unwrap();
+    state
+        .add_log(Level::Info, "two".into(), None)
+        .await
+        .unwrap();
+    state
+        .add_log(Level::Info, "three".into(), None)
+        .await
+        .unwrap();
 
     let logs = commands::get_logs(state).await.unwrap();
     assert_eq!(logs.len(), 2);
@@ -250,7 +265,10 @@ async fn command_set_exit_country_invalid() {
     app.manage(mock_state());
     let state = app.state::<AppState<MockTorClient>>();
     let res = commands::set_exit_country(state, Some("zzz".into())).await;
-    assert!(matches!(res, Err(Error::Tor(_))));
+    match res {
+        Err(Error::ConnectionFailed { step, .. }) => assert_eq!(step, "set_exit_country"),
+        _ => panic!("expected connection failed"),
+    }
 }
 
 #[tokio::test]

--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -265,6 +265,16 @@ async fn connect_rate_limited() {
     assert!(matches!(last, Err(Error::RateLimited(_))));
 }
 
+#[tokio::test]
+async fn set_exit_country_invalid_error_variant() {
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    let res = manager.set_exit_country(Some("zzz".into())).await;
+    match res {
+        Err(Error::ConnectionFailed { step, .. }) => assert_eq!(step, "set_exit_country"),
+        _ => panic!("expected connection failed"),
+    }
+}
+
 #[test]
 fn bridge_preset_loading() {
     let json = r#"{ "presets": [ { "name": "set1", "bridges": ["b1", "b2"] } ] }"#;


### PR DESCRIPTION
## Summary
- propagate error step via `ConnectionFailed` in TorManager
- expose step to UI events in `connect`
- adapt tests for new error variants

## Testing
- `cargo test` *(fails: glib-sys missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869a3bc6adc83338f40c0ff6a967cbd