### PR TITLE
Add circuit build metrics

### DIFF
--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -324,7 +324,7 @@ async fn tray_warning_set_and_cleared() {
     let state = app.state::<AppState<MockTorClient>>();
 
     // trigger warning
-    state.update_metrics(2 * 1024 * 1024, 0).await;
+    state.update_metrics(2 * 1024 * 1024, 0, 0, 0, 0).await;
     assert!(state.tray_warning.lock().await.is_some());
 
     // clear warning

--- a/src-tauri/tests/state_tests.rs
+++ b/src-tauri/tests/state_tests.rs
@@ -85,7 +85,7 @@ async fn update_metrics_closes_circuits_on_limit() {
         tray_warning: Arc::new(Mutex::new(None)),
     };
     let _ = tokio::fs::remove_file("state.log").await;
-    state.update_metrics(2 * 1024 * 1024, 2, 0).await;
+    state.update_metrics(2 * 1024 * 1024, 2, 0, 0, 0).await;
 
     assert!(*flag.lock().unwrap());
     let logs = state.read_logs().await.unwrap();
@@ -117,7 +117,7 @@ async fn tray_warning_on_memory_limit() {
         tray_warning: Arc::new(Mutex::new(None)),
     };
     let _ = tokio::fs::remove_file("mem.log").await;
-    state.update_metrics(2 * 1024 * 1024, 0, 0).await;
+    state.update_metrics(2 * 1024 * 1024, 0, 0, 0, 0).await;
     assert!(state.tray_warning.lock().await.as_ref().unwrap().contains("memory"));
 }
 
@@ -146,7 +146,7 @@ async fn tray_warning_on_circuit_limit() {
         tray_warning: Arc::new(Mutex::new(None)),
     };
     let _ = tokio::fs::remove_file("circ.log").await;
-    state.update_metrics(0, 2, 0).await;
+    state.update_metrics(0, 2, 0, 0, 0).await;
     assert!(state.tray_warning.lock().await.as_ref().unwrap().contains("circuit"));
 }
 

--- a/src-tauri/tests/tor_manager_metrics_tests.rs
+++ b/src-tauri/tests/tor_manager_metrics_tests.rs
@@ -108,4 +108,6 @@ async fn circuit_metrics_connected() {
     let metrics = manager.circuit_metrics().await.unwrap();
     assert_eq!(metrics.count, 0);
     assert_eq!(metrics.oldest_age, 0);
+    assert_eq!(metrics.build_ms, 0);
+    assert_eq!(metrics.connect_ms, 0);
 }

--- a/src/__tests__/TorStore.spec.ts
+++ b/src/__tests__/TorStore.spec.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, vi } from 'vitest';
 import { get } from 'svelte/store';
 
 let statusCallback: (event: any) => void = () => {};
+let metricsCallback: (event: any) => void = () => {};
 vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn((event: string, cb: any) => {
     if (event === 'tor-status-update') statusCallback = cb;
+    if (event === 'metrics-update') metricsCallback = cb;
   })
 }));
 vi.mock('@tauri-apps/api/tauri', () => ({ invoke: vi.fn() }));
@@ -15,5 +17,24 @@ describe('torStore', () => {
   it('sets status to ERROR on failed connection', () => {
     statusCallback({ payload: { status: 'ERROR', errorMessage: 'fail' } });
     expect(get(torStore).status).toBe('ERROR');
+  });
+
+  it('updates metrics from backend events', () => {
+    metricsCallback({
+      payload: {
+        memory_bytes: 1_000_000,
+        circuit_count: 1,
+        latency_ms: 50,
+        oldest_age: 2,
+        build_ms: 100,
+        connect_ms: 200,
+      }
+    });
+    const state = get(torStore);
+    expect(state.memoryUsageMB).toBe(1);
+    expect(state.circuitCount).toBe(1);
+    expect(state.pingMs).toBe(50);
+    expect(state.metrics.at(-1)?.buildMs).toBe(100);
+    expect(state.metrics.at(-1)?.connectMs).toBe(200);
   });
 });

--- a/src/lib/components/MetricsChart.svelte
+++ b/src/lib/components/MetricsChart.svelte
@@ -21,6 +21,8 @@
   $: memoryPath = buildPath(metrics, "memoryMB");
   $: circuitPath = buildPath(metrics, "circuitCount");
   $: agePath = buildPath(metrics, "oldestAge");
+  $: buildPathLine = buildPath(metrics, "buildMs");
+  $: connectPath = buildPath(metrics, "connectMs");
 </script>
 
 <svg {width} {height} class="text-green-400" role="img" aria-label="Tor metrics chart">
@@ -38,6 +40,22 @@
       d={circuitPath}
       fill="none"
       stroke="blue"
+      stroke-width="1"
+    />
+  {/if}
+  {#if buildPathLine}
+    <path
+      d={buildPathLine}
+      fill="none"
+      stroke="red"
+      stroke-width="1"
+    />
+  {/if}
+  {#if connectPath}
+    <path
+      d={connectPath}
+      fill="none"
+      stroke="purple"
       stroke-width="1"
     />
   {/if}

--- a/src/lib/stores/torStore.ts
+++ b/src/lib/stores/torStore.ts
@@ -30,6 +30,8 @@ export interface MetricPoint {
   circuitCount: number;
   latencyMs: number;
   oldestAge: number;
+  buildMs: number;
+  connectMs: number;
 }
 
 function createTorStore() {
@@ -58,6 +60,8 @@ function createTorStore() {
       circuitCount: event.payload.circuit_count,
       latencyMs: event.payload.latency_ms,
       oldestAge: event.payload.oldest_age ?? 0,
+      buildMs: event.payload.build_ms ?? 0,
+      connectMs: event.payload.connect_ms ?? 0,
     };
     update((state) => {
       const metrics = [...state.metrics, point].slice(-MAX_POINTS);
@@ -66,6 +70,7 @@ function createTorStore() {
         memoryUsageMB: point.memoryMB,
         circuitCount: point.circuitCount,
         pingMs: point.latencyMs,
+        // could expose build/connect metrics individually later
         metrics,
       };
     });


### PR DESCRIPTION
## Summary
- capture circuit build and connection latency in TorManager
- persist those metrics in AppState and forward via events
- show new metrics in torStore and MetricsChart
- update tests for new behavior

## Testing
- `cargo test` *(fails: The system library `glib-2.0` was not found)*
- `bun run test` *(fails: vitest: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a3bd5754833387498e801f103536