### PR TITLE
Add system notifications for security events

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -471,7 +471,13 @@ impl<C: TorClientBehavior> AppState<C> {
     /// Emit a security warning event to the frontend
     pub async fn emit_security_warning(&self, message: String) {
         if let Some(handle) = self.app_handle.lock().await.as_ref() {
-            let _ = handle.emit_all("security-warning", message);
+            let _ = handle.emit_all("security-warning", message.clone());
+            let _ = tauri::api::notification::Notification::new(
+                &handle.config().tauri.bundle.identifier,
+            )
+            .title("Torwell84 Warning")
+            .body(&message)
+            .show();
         }
     }
 

--- a/src/__tests__/SecurityBanner.spec.ts
+++ b/src/__tests__/SecurityBanner.spec.ts
@@ -1,13 +1,19 @@
 import { render } from '@testing-library/svelte';
 import { vi, describe, it, expect } from 'vitest';
 import { tick } from 'svelte';
+import { sendNotification } from '@tauri-apps/api/notification';
 
 var warningCallback: (event: any) => void = () => {};
 vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn((_event: string, cb: any) => {
-    if (_event === 'security-warning') warningCallback = cb;
+    if (_event === 'security-warning')
+      warningCallback = (e: any) => {
+        sendNotification({ title: 'Torwell84 Warning', body: e.payload });
+        cb(e);
+      };
   })
 }));
+vi.mock('@tauri-apps/api/notification', () => ({ sendNotification: vi.fn() }));
 
 import SecurityBanner from '../lib/components/SecurityBanner.svelte';
 
@@ -20,5 +26,6 @@ describe('SecurityBanner', () => {
     await tick();
 
     expect(getByRole('alert')).toHaveTextContent('warning msg');
+    expect(sendNotification).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- trigger OS notification when emitting a security warning
- simulate backend notification in SecurityBanner unit test

## Testing
- `bun run test` *(fails: Could not find `.svelte-kit/tsconfig.json` and other Vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869aab80a408333a7c3af06deeb9e49