### PR TITLE
Add Capacitor mobile skeleton with HTTP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,9 @@ The connection code already implements backoff with a maximum total time and log
 ## ⚠ Known Limitations
 See [docs/Limitations.md](docs/Limitations.md) for features that are currently impossible to implement, including per-circuit metrics.
 
+## 📱 Mobile
+Experimental Capacitor configuration is provided in [docs/Mobile.md](docs/Mobile.md). Use `task mobile:android` or `task mobile:ios` to build the mobile apps. The mobile build communicates with the Rust backend over a small HTTP bridge running on port 1421 when compiled with the `mobile` feature.
+
 ## 🔐 Security Findings
 Aktuelle Erkenntnisse aus Audits sind im Dokument [docs/SecurityFindings.md](docs/SecurityFindings.md) zusammengefasst.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,3 +24,13 @@ tasks:
     desc: "Builds the application for production."
     cmds:
       - bun tauri build
+
+  mobile:android:
+    desc: "Build the Android app using Capacitor"
+    cmds:
+      - ./mobile/scripts/build_android.sh
+
+  mobile:ios:
+    desc: "Build the iOS app using Capacitor"
+    cmds:
+      - ./mobile/scripts/build_ios.sh

--- a/docs/Mobile.md
+++ b/docs/Mobile.md
@@ -1,0 +1,23 @@
+# Mobile Build
+
+This directory contains the configuration for the Capacitor based mobile build.
+The Svelte frontend is reused by pointing `webDir` to the compiled web assets.
+
+## Build Scripts
+
+Use the `Taskfile` targets to build the apps:
+
+```bash
+task mobile:android  # Build Android APK
+task mobile:ios      # Build iOS project
+```
+
+The scripts under `mobile/scripts` run `bun run build` to generate the web
+assets and then invoke Capacitor CLI to sync and build the native projects.
+
+## IPC Bridge
+
+When compiled with the `mobile` feature, the Rust backend starts a small HTTP
+server on port `1421` to allow the mobile shell to communicate with the Tor
+manager. The Capacitor app can perform requests to this server to control the
+Tor connection.

--- a/mobile/capacitor.config.ts
+++ b/mobile/capacitor.config.ts
@@ -1,0 +1,10 @@
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.torwell.mobile',
+  appName: 'Torwell84',
+  webDir: '../build',
+  bundledWebRuntime: false
+};
+
+export default config;

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "torwell-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "sync": "npx cap sync",
+    "android": "npx cap run android",
+    "ios": "npx cap run ios"
+  },
+  "dependencies": {
+    "@capacitor/core": "^5.0.0"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "^5.0.0",
+    "@capacitor/android": "^5.0.0",
+    "@capacitor/ios": "^5.0.0"
+  }
+}

--- a/mobile/scripts/build_android.sh
+++ b/mobile/scripts/build_android.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
+
+# Build the Svelte frontend
+bun run build
+
+# Build the Android app using Capacitor
+cd "$SCRIPT_DIR/.."
+bun install
+npx cap sync android
+npx cap build android

--- a/mobile/scripts/build_ios.sh
+++ b/mobile/scripts/build_ios.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
+
+# Build the Svelte frontend
+bun run build
+
+# Build the iOS app using Capacitor
+cd "$SCRIPT_DIR/.."
+bun install
+npx cap sync ios
+npx cap build ios

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ urlencoding = "2"
 anyhow = "1"
 sysinfo = "0.30"
 governor = "0.10.0"
+axum = "0.7"
 directories = "6.0"
 keyring = "2"
 rand = "0.8"
@@ -57,3 +58,4 @@ default = ["custom-protocol"]
 # this feature is used used for production builds where `devPath` points to the filesystem
 # DO NOT remove this
 custom-protocol = ["tauri/custom-protocol"]
+mobile = []

--- a/src-tauri/src/http_bridge.rs
+++ b/src-tauri/src/http_bridge.rs
@@ -1,0 +1,28 @@
+use axum::{routing::get, Router, Json, extract::Extension};
+use std::{net::SocketAddr, sync::Arc};
+use crate::state::AppState;
+
+async fn status(Extension(state): Extension<Arc<AppState>>) -> Json<&'static str> {
+    let s = if state.tor_manager.is_connected().await {
+        "CONNECTED"
+    } else {
+        "DISCONNECTED"
+    };
+    Json(s)
+}
+
+pub fn start(state: AppState) {
+    let router = Router::new()
+        .route("/status", get(status))
+        .layer(Extension(Arc::new(state)));
+
+    tauri::async_runtime::spawn(async move {
+        let addr = SocketAddr::from(([127, 0, 0, 1], 1421));
+        if let Err(e) = axum::Server::bind(&addr)
+            .serve(router.into_make_service())
+            .await
+        {
+            eprintln!("HTTP bridge failed: {e}");
+        }
+    });
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ mod secure_http;
 mod session;
 mod state;
 mod tor_manager;
+#[cfg(feature = "mobile")]
+mod http_bridge;
 
 use secure_http::SecureHttpClient;
 use state::AppState;
@@ -22,6 +24,9 @@ pub fn run() {
         .expect("failed to initialize http client")
     });
     let app_state = AppState::new(http_client.clone());
+
+    #[cfg(feature = "mobile")]
+    http_bridge::start(app_state.clone());
 
     let quit = CustomMenuItem::new("quit", "Quit");
     let show = CustomMenuItem::new("show", "Show");


### PR DESCRIPTION
## Summary
- add `mobile` folder with Capacitor config and build scripts
- document how to build mobile apps
- add new `mobile:android` and `mobile:ios` tasks
- add HTTP bridge for mobile feature and start it in `run`
- depend on `axum` for the bridge
- mention the mobile build in the README

## Testing
- `cargo test` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869aac1fa44833381b1857920930de5