### PR TITLE
Add optional HSM support via pkcs11

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ You can influence certain backend parameters via environment variables:
 - `TORWELL_MAX_LOG_LINES` – Maximum number of log lines kept in `torwell.log` (default `1000`).
 - `TORWELL_MAX_MEMORY_MB` – Memory usage threshold before warnings (default `1024`).
 - `TORWELL_MAX_CIRCUITS` – Maximum allowed parallel circuits (default `20`).
+- `TORWELL_HSM_LIB` – Path to the PKCS#11 module when compiled with the `hsm` feature.
 
 > The first build will download many Rust crates and may take several minutes.
 
@@ -357,6 +358,7 @@ See [docs/Limitations.md](docs/Limitations.md) for features that are currently i
 
 ## 📱 Mobile
 Experimental Capacitor configuration is provided in [docs/Mobile.md](docs/Mobile.md). Use `task mobile:android` or `task mobile:ios` to build the mobile apps. The mobile build communicates with the Rust backend over a small HTTP bridge running on port 1421 when compiled with the `mobile` feature.
+Guidance for using a Hardware Security Module is available in [docs/HSM.md](docs/HSM.md).
 
 ## 🔐 Security Findings
 Aktuelle Erkenntnisse aus Audits sind im Dokument [docs/SecurityFindings.md](docs/SecurityFindings.md) zusammengefasst.

--- a/docs/HSM.md
+++ b/docs/HSM.md
@@ -1,0 +1,28 @@
+# Hardware Security Module (HSM) Support
+
+Starting with version 2.4 the backend can manage keys via a PKCS#11 module.
+This functionality is compiled in by enabling the `hsm` feature.
+
+## Building with HSM support
+
+```bash
+cargo build --release --manifest-path src-tauri/Cargo.toml --features hsm
+```
+
+The PKCS#11 library path is read from the `TORWELL_HSM_LIB` environment
+variable. If unset, `/usr/lib/softhsm/libsofthsm2.so` is used.
+
+Example using a YubiHSM:
+
+```bash
+TORWELL_HSM_LIB=/usr/local/lib/libyubihsm_pkcs11.so \
+    bun tauri build --features hsm
+```
+
+## Usage in SecureHttpClient
+
+When the feature is enabled `SecureHttpClient` initialises the PKCS#11
+context during TLS configuration. Keys stored on the HSM can be accessed
+through the loaded module. The current implementation only loads the
+module and finalises it again; you can extend `secure_http.rs` to fetch
+certificates or signing keys as needed.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ directories = "6.0"
 keyring = "2"
 rand = "0.8"
 surge-ping = "0.8"
+pkcs11 = { version = "0.5", optional = true }
 
 [dev-dependencies]
 async-trait = "0.1"
@@ -59,3 +60,4 @@ default = ["custom-protocol"]
 # DO NOT remove this
 custom-protocol = ["tauri/custom-protocol"]
 mobile = []
+hsm = ["pkcs11"]


### PR DESCRIPTION
## Summary
- introduce optional `hsm` feature flag in Cargo manifest
- add pkcs11 crate as optional dependency
- integrate HSM initialisation in `SecureHttpClient`
- document HSM configuration and usage
- note `TORWELL_HSM_LIB` environment variable in README

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml --all-features` *(fails: glib-2.0 not found)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b0095a1c8333aed1fed3d7ddc6b2