### PR TITLE
Add ResourceDashboard component

### DIFF
--- a/src/__tests__/ResourceDashboard.spec.ts
+++ b/src/__tests__/ResourceDashboard.spec.ts
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/svelte';
+import { vi, describe, it, expect } from 'vitest';
+import { tick } from 'svelte';
+
+let metricsCallback: (e: any) => void = () => {};
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn((ev: string, cb: any) => {
+    if (ev === 'metrics-update') metricsCallback = cb;
+  })
+}));
+
+import ResourceDashboard from '../lib/components/ResourceDashboard.svelte';
+
+describe('ResourceDashboard', () => {
+  it('updates metrics and shows warnings', async () => {
+    const { getByText, getAllByRole } = render(ResourceDashboard);
+
+    metricsCallback({ payload: { memory_bytes: 1500_000_000, circuit_count: 25, latency_ms: 0, oldest_age: 0 } });
+    await tick();
+
+    expect(getByText('Memory: 1500 MB')).toBeInTheDocument();
+    expect(getByText('Circuits: 25')).toBeInTheDocument();
+    expect(getAllByRole('alert').length).toBe(2);
+  });
+});

--- a/src/lib/components/ResourceDashboard.svelte
+++ b/src/lib/components/ResourceDashboard.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { listen } from '@tauri-apps/api/event';
+  import MetricsChart from './MetricsChart.svelte';
+  import type { MetricPoint } from '$lib/stores/torStore';
+
+  let metrics: MetricPoint[] = [];
+  const MAX_POINTS = 30;
+
+  const MAX_MEMORY_MB = 1024;
+  const MAX_CIRCUITS = 20;
+
+  $: latest = metrics[metrics.length - 1] ?? { memoryMB: 0, circuitCount: 0, latencyMs: 0, oldestAge: 0, time: 0 };
+
+  onMount(() => {
+    listen<any>('metrics-update', (event) => {
+      const point: MetricPoint = {
+        time: Date.now(),
+        memoryMB: Math.round(event.payload.memory_bytes / 1_000_000),
+        circuitCount: event.payload.circuit_count,
+        latencyMs: event.payload.latency_ms,
+        oldestAge: event.payload.oldest_age ?? 0
+      };
+      metrics = [...metrics, point].slice(-MAX_POINTS);
+    });
+  });
+</script>
+
+<div class="glass-md rounded-xl p-4 space-y-4" role="region" aria-label="Resource dashboard">
+  <div class="flex gap-4">
+    <div class="flex-1">
+      <p class="text-sm text-white">Memory: {latest.memoryMB} MB</p>
+      {#if latest.memoryMB > MAX_MEMORY_MB}
+        <p class="text-sm text-red-400" role="alert">Memory usage high</p>
+      {/if}
+    </div>
+    <div class="flex-1">
+      <p class="text-sm text-white">Circuits: {latest.circuitCount}</p>
+      {#if latest.circuitCount > MAX_CIRCUITS}
+        <p class="text-sm text-red-400" role="alert">Circuit count high</p>
+      {/if}
+    </div>
+  </div>
+  <MetricsChart {metrics} />
+</div>
+
+<style>
+  .glass-md {
+    @apply bg-white/20 backdrop-blur-xl;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -142,6 +142,9 @@
       retryCount={$torStore.retryCount}
       retryDelay={$torStore.retryDelay}
     />
+    <div class="text-right mt-2">
+      <a href="/dashboard" class="text-sm text-blue-400 underline">Resource Dashboard</a>
+    </div>
   </div>
 </div>
 

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import ResourceDashboard from '$lib/components/ResourceDashboard.svelte';
+</script>
+
+<div class="p-6 max-w-6xl mx-auto">
+  <a href="/" class="text-blue-400 underline">Back</a>
+  <ResourceDashboard />
+</div>


### PR DESCRIPTION
## Summary
- add ResourceDashboard.svelte with metrics-update event
- create /dashboard route to display Resource Dashboard
- link to dashboard from home page
- test ResourceDashboard component

## Testing
- `bun x vitest run` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6869b4a5df6c8333adcd99b47c42b3f9