### PR TITLE
Improve Tor connection error context

### DIFF
--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -297,7 +297,7 @@ impl<C: TorClientBehavior> TorManager<C> {
         progress(0, "starting".into());
         let config = self.build_config().await.map_err(|e| {
             log::error!("connect_once: build_config failed: {e}");
-            Error::ConfigError {
+            Error::ConnectionFailed {
                 step: "build_config".into(),
                 source: e.to_string(),
             }
@@ -306,7 +306,7 @@ impl<C: TorClientBehavior> TorManager<C> {
             .await
             .map_err(|e| {
                 log::error!("connect_once: bootstrap failed: {e}");
-                Error::NetworkFailure {
+                Error::ConnectionFailed {
                     step: "bootstrap".into(),
                     source: e,
                 }


### PR DESCRIPTION
## Summary
- enrich `connect_once` errors with `ConnectionFailed`
- adjust tests for the new error variant
- test `new_identity` rate-limiting

## Testing
- `cargo test --tests` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869b4a68fa48333b4e0df59e4516d53