### PR TITLE
Update mobile build scripts

### DIFF
--- a/docs/Mobile.md
+++ b/docs/Mobile.md
@@ -3,21 +3,24 @@
 This directory contains the configuration for the Capacitor based mobile build.
 The Svelte frontend is reused by pointing `webDir` to the compiled web assets.
 
-## Build Scripts
+## Build Steps
 
-Use the `Taskfile` targets to build the apps:
+1. Run `task setup` once to install all dependencies.
+2. Use the `Taskfile` targets to build the apps:
 
-```bash
-task mobile:android  # Build Android APK
-task mobile:ios      # Build iOS project
-```
+   ```bash
+   task mobile:android  # Build Android APK
+   task mobile:ios      # Build iOS project
+   ```
 
-The scripts under `mobile/scripts` run `bun run build` to generate the web
-assets and then invoke Capacitor CLI to sync and build the native projects.
+   Each task performs the following:
+   - `bun run build` generates the web assets in `build/`.
+   - `cargo build --release --manifest-path src-tauri/Cargo.toml --features mobile` compiles the Rust backend so the HTTP bridge is included.
+   - The Capacitor CLI then syncs and builds the native project.
 
 ## IPC Bridge
 
-When compiled with the `mobile` feature, the Rust backend starts a small HTTP
-server on port `1421` to allow the mobile shell to communicate with the Tor
-manager. The Capacitor app can perform requests to this server to control the
-Tor connection.
+When compiled with the `mobile` feature, the Rust backend automatically launches
+a small HTTP server listening on `http://127.0.0.1:1421`. The Capacitor shell
+communicates with this server to control the Tor connection. Make sure requests
+target this port when running the mobile app.

--- a/mobile/scripts/build_android.sh
+++ b/mobile/scripts/build_android.sh
@@ -3,8 +3,13 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
 
+
 # Build the Svelte frontend
 bun run build
+
+# Compile the Rust backend with the `mobile` feature so the HTTP bridge is
+# available when the app runs.
+cargo build --release --manifest-path "$ROOT_DIR/src-tauri/Cargo.toml" --features mobile
 
 # Build the Android app using Capacitor
 cd "$SCRIPT_DIR/.."

--- a/mobile/scripts/build_ios.sh
+++ b/mobile/scripts/build_ios.sh
@@ -3,8 +3,13 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
 
+
 # Build the Svelte frontend
 bun run build
+
+# Compile the Rust backend with the `mobile` feature so the HTTP bridge is
+# available when the app runs.
+cargo build --release --manifest-path "$ROOT_DIR/src-tauri/Cargo.toml" --features mobile
 
 # Build the iOS app using Capacitor
 cd "$SCRIPT_DIR/.."


### PR DESCRIPTION
## Summary
- build Rust backend in mobile scripts using the `mobile` feature
- document updated build process and port requirement

## Testing
- `bun run check` *(fails: svelte-check found errors)*
- `bun run lint:a11y` *(fails: svelte-check found errors)*
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: system library glib-2.0 not found)*
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` *(fails: 'cargo-clippy' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869b4abefb88333823b62f17cf7b0b4