### PR TITLE
Add production certificate instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ The minimum TLS version can also be configured via the `min_tls_version` field
 
 For a detailed description of the certificate rotation process, see
 [docs/CertificateManagement.md#rotation-workflow](docs/CertificateManagement.md#rotation-workflow).
+Instructions for creating your own production certificate are available in
+[docs/ProductionCertificate.md](docs/ProductionCertificate.md).
 
 Example for development:
 

--- a/docs/ProductionCertificate.md
+++ b/docs/ProductionCertificate.md
@@ -1,0 +1,52 @@
+# Production Certificate
+
+This guide explains how to provide your own server certificate for Torwell84 deployments. The application pins a certificate and checks for updates at runtime. Follow these steps to prepare a production setup.
+
+## 1. Generate a Certificate
+
+Create a PEM encoded certificate with your internal or public CA. For quick testing you can use OpenSSL:
+
+```bash
+openssl req -new -newkey rsa:4096 -days 90 -nodes -x509 \
+    -keyout server.key -out server.pem \
+    -subj "/CN=updates.torwell.com"
+```
+
+Place `server.pem` on your update server. Renew the file every 90 days.
+
+## 2. Adjust `cert_config.json`
+
+Edit `src-tauri/certs/cert_config.json` and set `cert_url` to the HTTPS endpoint where `server.pem` is hosted. Optionally change `cert_path` if you want to store the file in another location.
+
+```json
+{
+  "cert_path": "src-tauri/certs/server.pem",
+  "cert_url": "https://updates.example.org/certs/server.pem",
+  "fallback_cert_url": null,
+  "min_tls_version": "1.2"
+}
+```
+
+## 3. Override via Environment Variables
+
+Instead of editing the configuration file you can override the values at runtime:
+
+```bash
+export TORWELL_CERT_URL=https://updates.example.org/certs/server.pem
+export TORWELL_CERT_PATH=/etc/torwell/server.pem
+```
+
+`SecureHttpClient` prefers environment variables over `cert_config.json` when no parameters are passed to `init`.
+
+## 4. Rotation Script Example
+
+Automate certificate updates with a small script that copies the new PEM to the update server. Trigger it from a cronjob or CI pipeline.
+
+```bash
+#!/bin/bash
+set -e
+scp /pki/torwell/server.pem \
+    user@updates.example.org:/var/www/certs/server.pem
+```
+
+Running this script after each renewal ensures that clients download the new certificate during the next update check.


### PR DESCRIPTION
## Summary
- document how to create a production certificate and rotate it
- reference the new doc from the README

## Testing
- `bun install`
- `bun run check` *(fails: svelte-check found 4 errors)*
- `bun run lint:a11y` *(fails: svelte-check found 4 errors)*
- `cargo check` *(fails: missing `glib-2.0` library)*
- `cargo clippy -- -D warnings` *(fails: component `clippy` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869b4aed08483338edf8b216047e5a3