### PR TITLE
Implement network diagnostics

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ keyring = "2"
 rand = "0.8"
 surge-ping = "0.8"
 pkcs11 = { version = "0.5", optional = true }
+traceroute = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 async-trait = "0.1"
@@ -61,3 +62,5 @@ default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
 mobile = []
 hsm = ["pkcs11"]
+dns_lookup = []
+traceroute = ["dep:traceroute"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,6 +143,10 @@ pub fn run() {
             commands::get_log_file_path,
             commands::set_log_limit,
             commands::ping_host,
+            #[cfg(feature = "dns_lookup")]
+            commands::dns_lookup,
+            #[cfg(feature = "traceroute")]
+            commands::traceroute_host,
             commands::get_secure_key,
             commands::set_secure_key,
             commands::request_token

--- a/src-tauri/tests/pentest.rs
+++ b/src-tauri/tests/pentest.rs
@@ -73,3 +73,38 @@ async fn pentest_invalid_token_and_rate_limit() {
     }
     assert!(matches!(last, Err(Error::RateLimitExceeded(_))));
 }
+
+#[cfg(feature = "dns_lookup")]
+#[tokio::test]
+async fn dns_lookup_invalid_and_rate_limit() {
+    let mut app = tauri::test::mock_app();
+    let state = mock_state();
+    app.manage(state);
+    let state = app.state::<AppState<MockTorClient>>();
+    let token = state.create_session().await;
+
+    let res = commands::dns_lookup(state, token.clone(), "bad host$".into()).await;
+    assert!(matches!(res, Err(Error::Io(_))));
+
+    let mut last = Ok(Vec::new());
+    for _ in 0..65 {
+        last = commands::dns_lookup(state, token.clone(), "localhost".into()).await;
+    }
+    assert!(matches!(last, Err(Error::RateLimitExceeded(_))));
+}
+
+#[cfg(feature = "traceroute")]
+#[tokio::test]
+async fn traceroute_rate_limited() {
+    let mut app = tauri::test::mock_app();
+    let state = mock_state();
+    app.manage(state);
+    let state = app.state::<AppState<MockTorClient>>();
+    let token = state.create_session().await;
+
+    let mut last = Ok(Vec::new());
+    for _ in 0..65 {
+        last = commands::traceroute_host(state, token.clone(), "localhost".into(), Some(1)).await;
+    }
+    assert!(matches!(last, Err(Error::RateLimitExceeded(_))));
+}

--- a/src/__tests__/NetworkTools.spec.ts
+++ b/src/__tests__/NetworkTools.spec.ts
@@ -1,0 +1,17 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/tauri', () => ({ invoke: vi.fn(async () => 42) }));
+
+import NetworkTools from '../lib/components/NetworkTools.svelte';
+import { invoke } from '@tauri-apps/api/tauri';
+
+describe('NetworkTools', () => {
+  it('calls dns_lookup on button click', async () => {
+    const { getByText, getByLabelText } = render(NetworkTools);
+    const input = getByLabelText('Host') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'example.com' } });
+    await fireEvent.click(getByText('DNS Lookup'));
+    expect(invoke).toHaveBeenNthCalledWith(2, 'dns_lookup', { token: 42, host: 'example.com' });
+  });
+});

--- a/src/lib/components/NetworkTools.svelte
+++ b/src/lib/components/NetworkTools.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { invoke } from "$lib/api";
+  let host = "";
+  let dns: string[] = [];
+  let route: string[] = [];
+  let loading = false;
+
+  async function lookup() {
+    if (!host) return;
+    loading = true;
+    try {
+      dns = (await invoke("dns_lookup", { host })) as string[];
+    } catch (e) {
+      dns = ["error"];
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function trace() {
+    if (!host) return;
+    loading = true;
+    try {
+      route = (await invoke("traceroute_host", { host, maxHops: 8 })) as string[];
+    } catch (e) {
+      route = ["error"];
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<div class="glass-md rounded-xl p-4 flex flex-col gap-2" aria-label="Network tools">
+  <div>
+    <label class="text-sm text-white">Host</label>
+    <input class="ml-2 p-1 rounded text-black" bind:value={host} />
+  </div>
+  <div class="flex gap-2">
+    <button class="glass px-2 py-1 rounded" on:click|preventDefault={lookup} disabled={loading}>DNS Lookup</button>
+    <button class="glass px-2 py-1 rounded" on:click|preventDefault={trace} disabled={loading}>Traceroute</button>
+  </div>
+  {#if dns.length}
+    <div class="text-xs text-white break-all">DNS: {dns.join(", ")}</div>
+  {/if}
+  {#if route.length}
+    <div class="text-xs text-white break-all">Route: {route.join(" -> ")}</div>
+  {/if}
+</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import TorChain from "$lib/components/TorChain.svelte";
   import ActionCard from "$lib/components/ActionCard.svelte";
   import IdlePanel from "$lib/components/IdlePanel.svelte";
+  import NetworkTools from "$lib/components/NetworkTools.svelte";
   import SecurityBanner from "$lib/components/SecurityBanner.svelte";
   import { browser } from "$app/environment";
   let LogsModalComponent: any = null;
@@ -134,6 +135,8 @@
       on:openLogs={() => uiStore.actions.openLogsModal()}
       on:openSettings={() => uiStore.actions.openSettingsModal()}
     />
+
+    <NetworkTools />
 
     <IdlePanel
       connectionProgress={$torStore.bootstrapProgress}


### PR DESCRIPTION
## Summary
- add optional `dns_lookup` and `traceroute` features
- expose `dns_lookup` and `traceroute_host` commands
- show a new NetworkTools component in the UI
- test new frontend component and backend features

## Testing
- `cargo test` *(fails: glib-2.0 missing)*
- `cargo test --features dns_lookup,traceroute` *(fails: glib-2.0 missing)*
- `bun run check` *(fails: svelte-kit not found)*
- `bun run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b4af1c7c8333bd4ed073c5fe15c6