### PR TITLE
Add circuit management commands and UI

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -341,6 +341,20 @@ pub async fn new_identity(app_handle: tauri::AppHandle, state: State<'_, AppStat
     )?;
     Ok(())
 }
+
+#[tauri::command]
+pub async fn list_circuits(state: State<'_, AppState>) -> Result<Vec<u64>> {
+    track_call("list_circuits").await;
+    check_api_rate()?;
+    state.tor_manager.list_circuit_ids().await
+}
+
+#[tauri::command]
+pub async fn close_circuit(state: State<'_, AppState>, id: u64) -> Result<()> {
+    track_call("close_circuit").await;
+    check_api_rate()?;
+    state.tor_manager.close_circuit(id).await
+}
 #[tauri::command]
 pub async fn get_logs(state: State<'_, AppState>, token: String) -> Result<Vec<LogEntry>> {
     track_call("get_logs").await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,11 @@
 mod commands;
 mod error;
+#[cfg(feature = "mobile")]
+mod http_bridge;
 mod secure_http;
 mod session;
 mod state;
 mod tor_manager;
-#[cfg(feature = "mobile")]
-mod http_bridge;
 
 use secure_http::SecureHttpClient;
 use state::AppState;
@@ -138,6 +138,8 @@ pub fn run() {
             commands::list_bridge_presets,
             commands::get_traffic_stats,
             commands::get_metrics,
+            commands::list_circuits,
+            commands::close_circuit,
             commands::get_logs,
             commands::clear_logs,
             commands::get_log_file_path,

--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -247,6 +247,20 @@ async fn close_all_circuits_not_connected() {
 }
 
 #[tokio::test]
+async fn list_circuit_ids_not_connected() {
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    let res = manager.list_circuit_ids().await;
+    assert!(matches!(res, Err(Error::NotConnected)));
+}
+
+#[tokio::test]
+async fn close_circuit_not_connected() {
+    let manager: TorManager<MockTorClient> = TorManager::new();
+    let res = manager.close_circuit(1).await;
+    assert!(matches!(res, Err(Error::NotConnected)));
+}
+
+#[tokio::test]
 async fn connect_rate_limited() {
     for _ in 0..6 {
         MockTorClient::push_result(Ok(MockTorClient::default()));

--- a/src/lib/components/CircuitList.svelte
+++ b/src/lib/components/CircuitList.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { invoke } from '$lib/api';
+  export let show = false;
+  let circuits: number[] = [];
+
+  async function refresh() {
+    if (!show) return;
+    try {
+      circuits = await invoke('list_circuits');
+    } catch (e) {
+      console.error('list_circuits failed', e);
+      circuits = [];
+    }
+  }
+
+  async function close(id: number) {
+    try {
+      await invoke('close_circuit', { id });
+      await refresh();
+    } catch (e) {
+      console.error('close_circuit failed', e);
+    }
+  }
+
+  onMount(refresh);
+  $: if (show) refresh();
+</script>
+
+{#if show}
+<div class="glass-md rounded-xl p-4 mt-4" aria-label="Circuits">
+  <h3 class="text-base font-medium text-white mb-2">Circuits</h3>
+  <ul class="space-y-1">
+    {#each circuits as id}
+      <li class="flex items-center justify-between text-xs text-white bg-black/50 rounded px-2 py-1">
+        <span>#{id}</span>
+        <button class="text-red-200 hover:text-red-400" on:click={() => close(id)}>Close</button>
+      </li>
+    {/each}
+    {#if circuits.length === 0}
+      <li class="text-gray-300">No circuits</li>
+    {/if}
+  </ul>
+</div>
+{/if}

--- a/src/lib/components/StatusCard.svelte
+++ b/src/lib/components/StatusCard.svelte
@@ -2,6 +2,7 @@
   import { Activity, Zap } from "lucide-svelte";
   import { invoke } from "$lib/api";
   import MetricsChart from "./MetricsChart.svelte";
+  import CircuitList from "./CircuitList.svelte";
 
   export let status;
   export let totalTrafficMB = 0;
@@ -159,5 +160,6 @@
   {/if}
   <div class="mt-2">
     <MetricsChart {metrics} />
+    <CircuitList show={status === 'CONNECTED'} />
   </div>
 </div>


### PR DESCRIPTION
## Summary
- implement `list_circuit_ids` and `close_circuit` in TorManager
- add `list_circuits` and `close_circuit` commands
- expose commands through Tauri builder
- display circuits on frontend and allow closing them
- add integration tests for new TorManager functions

## Testing
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869b4ac4cc483338f8290a1123aaf96