### PR TITLE
Improve error context for TorManager operations

### DIFF
--- a/src-tauri/src/tor_manager.rs
+++ b/src-tauri/src/tor_manager.rs
@@ -299,7 +299,7 @@ impl<C: TorClientBehavior> TorManager<C> {
             log::error!("connect_once: build_config failed: {e}");
             Error::ConnectionFailed {
                 step: "build_config".into(),
-                source: e.to_string(),
+                source: format!("build_config: {e}"),
             }
         })?;
         let tor_client = C::create_bootstrapped_with_progress(config, progress)
@@ -308,7 +308,7 @@ impl<C: TorClientBehavior> TorManager<C> {
                 log::error!("connect_once: bootstrap failed: {e}");
                 Error::ConnectionFailed {
                     step: "bootstrap".into(),
-                    source: e,
+                    source: format!("bootstrap: {e}"),
                 }
             })?;
         *self.client.lock().await = Some(tor_client);
@@ -467,14 +467,14 @@ impl<C: TorClientBehavior> TorManager<C> {
             log::error!("new_identity: build_config failed: {}", e);
             Error::Identity {
                 step: "build_config".into(),
-                source: e.to_string(),
+                source: format!("build_config: {}", e),
             }
         })?;
         client.reconfigure(&config).map_err(|e| {
             log::error!("new_identity: reconfigure failed: {}", e);
             Error::Identity {
                 step: "reconfigure".into(),
-                source: e,
+                source: format!("reconfigure: {e}"),
             }
         })?;
         client.retire_all_circs();
@@ -484,7 +484,7 @@ impl<C: TorClientBehavior> TorManager<C> {
             log::error!("new_identity: build_circuit failed: {}", e);
             Error::Identity {
                 step: "build_circuit".into(),
-                source: e,
+                source: format!("build_circuit: {e}"),
             }
         })?;
 

--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -137,7 +137,10 @@ async fn bridge_parse_error() {
         .unwrap();
     let res = manager.connect().await;
     match res {
-        Err(Error::ConnectionFailed { step, .. }) => assert_eq!(step, "build_config"),
+        Err(Error::ConnectionFailed { step, source }) => {
+            assert_eq!(step, "build_config");
+            assert!(source.contains("bridge parsing failed"));
+        }
         _ => panic!("expected connection failure"),
     }
 }
@@ -234,7 +237,10 @@ async fn new_identity_build_config_error() {
         .unwrap();
     let res = manager.new_identity().await;
     match res {
-        Err(Error::Identity { step, source: _ }) => assert_eq!(step, "build_config"),
+        Err(Error::Identity { step, source }) => {
+            assert_eq!(step, "build_config");
+            assert!(source.contains("bridge parsing failed"));
+        }
         _ => panic!("expected identity error"),
     }
 }


### PR DESCRIPTION
## Summary
- add detailed context for `ConnectionFailed` and `Identity` errors
- expose error source in command retries and failure events
- check that error messages contain bridge parse failures

## Testing
- `cargo check --no-default-features` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a4bee21288333a650591fa7d3012b