### PR TITLE
Implement HSM key loading for TLS

### DIFF
--- a/docs/HSM.md
+++ b/docs/HSM.md
@@ -10,7 +10,10 @@ cargo build --release --manifest-path src-tauri/Cargo.toml --features hsm
 ```
 
 The PKCS#11 library path is read from the `TORWELL_HSM_LIB` environment
-variable. If unset, `/usr/lib/softhsm/libsofthsm2.so` is used.
+variable. If unset, `/usr/lib/softhsm/libsofthsm2.so` is used. The slot
+number can be configured via `TORWELL_HSM_SLOT` (default `0`).
+Both values can also be stored in `src-tauri/app_config.json` under
+`hsm_lib` and `hsm_slot`.
 
 Example using a YubiHSM:
 
@@ -34,7 +37,17 @@ Example using a YubiHSM:
 ## Usage in SecureHttpClient
 
 When the feature is enabled `SecureHttpClient` initialises the PKCS#11
-context during TLS configuration. Keys stored on the HSM can be accessed
-through the loaded module. The current implementation only loads the
-module and finalises it again; you can extend `secure_http.rs` to fetch
-certificates or signing keys as needed.
+context during TLS configuration. The client looks for objects labelled
+`tls-cert` and `tls-key` on the configured slot and will use them for
+mutual TLS authentication. For testing you can provide base64 encoded
+values through the variables `TORWELL_HSM_MOCK_CERT` and
+`TORWELL_HSM_MOCK_KEY`.
+
+Example to run the binary with SoftHSM:
+
+```bash
+TORWELL_HSM_LIB=/usr/lib/softhsm/libsofthsm2.so \
+TORWELL_HSM_SLOT=0 \
+TORWELL_HSM_PIN=1234 \
+bun tauri dev --features hsm
+```

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 rustls = "0.23"
 rustls-pemfile = "2"
 urlencoding = "2"
+base64 = "0.21"
 anyhow = "1"
 sysinfo = "0.30"
 governor = "0.10.0"
@@ -55,6 +56,10 @@ once_cell = "1"
 logtest = "2"
 serial_test = "2"
 tempfile = "3"
+
+[package.metadata.hsm]
+library = "/usr/lib/softhsm/libsofthsm2.so"
+slot = 0
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/app_config.json
+++ b/src-tauri/app_config.json
@@ -1,4 +1,6 @@
 {
   "max_log_lines": 1000
   ,"geoip_path": null
+  ,"hsm_lib": null
+  ,"hsm_slot": 0
 }

--- a/src-tauri/tests/secure_http_tests.rs
+++ b/src-tauri/tests/secure_http_tests.rs
@@ -433,3 +433,45 @@ fn init_and_finalize_hsm_with_softhsm() {
     ctx.get_info().expect("C_GetInfo failed");
     torwell84::secure_http::finalize_hsm(ctx);
 }
+
+#[cfg(feature = "hsm")]
+#[test]
+fn hsm_mock_keypair_via_env() {
+    use base64::{engine::general_purpose, Engine as _};
+
+    std::env::set_var("TORWELL_HSM_LIB", "/usr/lib/softhsm/libsofthsm2.so");
+    let key_b64 = general_purpose::STANDARD.encode(include_bytes!("../tests_data/ca.key"));
+    let cert_b64 = general_purpose::STANDARD.encode(include_bytes!("../tests_data/ca.pem"));
+    std::env::set_var("TORWELL_HSM_MOCK_KEY", &key_b64);
+    std::env::set_var("TORWELL_HSM_MOCK_CERT", &cert_b64);
+
+    let (ctx, pair) = torwell84::secure_http::init_hsm().expect("init_hsm failed");
+    let pair = pair.expect("no key pair returned");
+    assert!(!pair.key.is_empty() && !pair.cert.is_empty());
+    torwell84::secure_http::finalize_hsm(ctx);
+
+    std::env::remove_var("TORWELL_HSM_MOCK_KEY");
+    std::env::remove_var("TORWELL_HSM_MOCK_CERT");
+}
+
+#[cfg(feature = "hsm")]
+#[tokio::test]
+async fn tls_config_uses_hsm_keys() {
+    use base64::{engine::general_purpose, Engine as _};
+    use rustls::client::ResolvesClientCert;
+
+    std::env::set_var("TORWELL_HSM_LIB", "/usr/lib/softhsm/libsofthsm2.so");
+    let key_b64 = general_purpose::STANDARD.encode(include_bytes!("../tests_data/ca.key"));
+    let cert_b64 = general_purpose::STANDARD.encode(include_bytes!("../tests_data/ca.pem"));
+    std::env::set_var("TORWELL_HSM_MOCK_KEY", &key_b64);
+    std::env::set_var("TORWELL_HSM_MOCK_CERT", &cert_b64);
+
+    let dir = tempdir().unwrap();
+    let cert_path = dir.path().join("pinned.pem");
+    fs::write(&cert_path, CA_PEM).unwrap();
+    let cfg = torwell84::secure_http::SecureHttpClient::build_tls_config(&cert_path).unwrap();
+    assert!(cfg.client_auth_cert_resolver.has_certs());
+
+    std::env::remove_var("TORWELL_HSM_MOCK_KEY");
+    std::env::remove_var("TORWELL_HSM_MOCK_CERT");
+}


### PR DESCRIPTION
## Summary
- expand PKCS#11 handling to fetch private key and cert
- expose HSM library and slot settings via Cargo metadata and app config
- document new variables and usage in docs/HSM.md
- allow mocking HSM objects via environment variables
- add unit tests for mocked HSM integration

## Testing
- `bun install`
- `bun run check` *(fails: svelte-check errors)*
- `bun run lint:a11y` *(fails: svelte-check errors)*
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a66a60ae08333a7dc497d8ceb038d