### PR TITLE
Add CircuitManager component

### DIFF
--- a/src/__tests__/CircuitManager.spec.ts
+++ b/src/__tests__/CircuitManager.spec.ts
@@ -1,0 +1,33 @@
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import { vi } from 'vitest';
+
+let circuits = [1, 2];
+vi.mock('@tauri-apps/api/tauri', () => ({
+  invoke: vi.fn(async (cmd: string, args: any) => {
+    if (cmd === 'request_token') return 42;
+    if (cmd === 'list_circuits') return circuits;
+    if (cmd === 'close_circuit') {
+      circuits = circuits.filter((id) => id !== args.id);
+      return;
+    }
+  })
+}));
+
+import CircuitManager from '../lib/components/CircuitManager.svelte';
+import { invoke } from '@tauri-apps/api/tauri';
+
+describe('CircuitManager', () => {
+  it('lists circuits and closes them', async () => {
+    const { findByText, getAllByText, queryByText } = render(CircuitManager);
+
+    await findByText('#1');
+    await findByText('#2');
+    expect(invoke).toHaveBeenNthCalledWith(2, 'list_circuits', { token: 42 });
+
+    await fireEvent.click(getAllByText('Close')[0]);
+    await waitFor(() => expect(queryByText('#1')).not.toBeInTheDocument());
+
+    expect(invoke).toHaveBeenNthCalledWith(3, 'close_circuit', { token: 42, id: 1 });
+    expect(invoke).toHaveBeenNthCalledWith(4, 'list_circuits', { token: 42 });
+  });
+});

--- a/src/lib/components/CircuitManager.svelte
+++ b/src/lib/components/CircuitManager.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { invoke } from '$lib/api';
+  let circuits: number[] = [];
+
+  async function refresh() {
+    try {
+      circuits = await invoke('list_circuits');
+    } catch (e) {
+      console.error('list_circuits failed', e);
+      circuits = [];
+    }
+  }
+
+  async function close(id: number) {
+    try {
+      await invoke('close_circuit', { id });
+      await refresh();
+    } catch (e) {
+      console.error('close_circuit failed', e);
+    }
+  }
+
+  onMount(refresh);
+</script>
+
+<div class="glass-md rounded-xl p-4" aria-label="Circuits">
+  <h3 class="text-base font-medium text-white mb-2">Circuits</h3>
+  <ul class="space-y-1">
+    {#each circuits as id}
+      <li class="flex items-center justify-between text-xs text-white bg-black/50 rounded px-2 py-1">
+        <span>#{id}</span>
+        <button class="text-red-200 hover:text-red-400" on:click={() => close(id)}>Close</button>
+      </li>
+    {/each}
+    {#if circuits.length === 0}
+      <li class="text-gray-300">No circuits</li>
+    {/if}
+  </ul>
+</div>

--- a/src/routes/circuits/+page.svelte
+++ b/src/routes/circuits/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import CircuitManager from '$lib/components/CircuitManager.svelte';
+</script>
+
+<div class="p-6 max-w-6xl mx-auto">
+  <a href="/" class="text-blue-400 underline">Back</a>
+  <CircuitManager class="mt-4" />
+</div>


### PR DESCRIPTION
## Summary
- create `CircuitManager` component for managing active circuits
- add `/circuits` route that renders the manager
- provide tests verifying listing and closing of circuits

## Testing
- `bun run test` *(fails: 10 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686a66a98f448333aef969968b7dae22