### PR TITLE
Implement extended connection diagnostics

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -122,7 +122,8 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
                             .await;
                     });
                     let (step, source) = match err {
-                        Error::ConnectionFailed { step, source } | Error::Identity { step, source } => (step, source),
+                        Error::ConnectionFailed { step, source, .. }
+                        | Error::Identity { step, source } => (step, source),
                         _ => ("", ""),
                     };
                     let _ = app_handle.emit_all(
@@ -166,9 +167,8 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
             }
             Err(e) => {
                 let (step, source) = match &e {
-                    Error::ConnectionFailed { step, source } | Error::Identity { step, source } => {
-                        (step.as_str(), source.as_str())
-                    }
+                    Error::ConnectionFailed { step, source, .. }
+                    | Error::Identity { step, source } => (step.as_str(), source.as_str()),
                     _ => ("", ""),
                 };
                 if let Err(e_emit) = app_handle.emit_all(
@@ -468,8 +468,7 @@ pub async fn traceroute_host(
     let limit = max_hops.unwrap_or(30) as usize;
     let hops = tokio::task::spawn_blocking(move || {
         let addr = format!("{}:0", host_clone);
-        let trace: TraceResult = traceroute::execute(addr.as_str())
-            .map_err(|e| e.to_string())?;
+        let trace: TraceResult = traceroute::execute(addr.as_str()).map_err(|e| e.to_string())?;
         let mut out = Vec::new();
         for hop in trace.take(limit) {
             let hop = hop.map_err(|e| e.to_string())?;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -36,8 +36,15 @@ pub enum Error {
     #[error("Network error: {0}")]
     Network(String),
 
-    #[error("connection failed during {step}: {source}")]
-    ConnectionFailed { step: String, source: String },
+    #[error(
+        "connection failed during {step} after {elapsed_ms}ms: {source} (last error: {last_error})"
+    )]
+    ConnectionFailed {
+        step: String,
+        source: String,
+        elapsed_ms: u64,
+        last_error: String,
+    },
 
     #[error("identity change failed during {step}: {source}")]
     Identity { step: String, source: String },


### PR DESCRIPTION
## Summary
- extend `Error::ConnectionFailed` with timing and last error fields
- include connection attempt duration in `TorManager::connect_once`
- adjust command handlers and tests for new fields
- add unit test verifying context information

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a66ab6fc48333aec4dfdb4dcce4b7