### PR TITLE
Implement metrics polling updates

### DIFF
--- a/src/__tests__/ResourceDashboard.spec.ts
+++ b/src/__tests__/ResourceDashboard.spec.ts
@@ -15,11 +15,22 @@ describe('ResourceDashboard', () => {
   it('updates metrics and shows warnings', async () => {
     const { getByText, getAllByRole } = render(ResourceDashboard);
 
-    metricsCallback({ payload: { memory_bytes: 1500_000_000, circuit_count: 25, latency_ms: 0, oldest_age: 0 } });
+    metricsCallback({
+      payload: {
+        memory_bytes: 1500_000_000,
+        circuit_count: 25,
+        latency_ms: 0,
+        oldest_age: 0,
+        avg_create_ms: 50,
+        failed_attempts: 3,
+      },
+    });
     await tick();
 
     expect(getByText('Memory: 1500 MB')).toBeInTheDocument();
     expect(getByText('Circuits: 25')).toBeInTheDocument();
+    expect(getByText('Avg build: 50 ms')).toBeInTheDocument();
+    expect(getByText('Failures: 3')).toBeInTheDocument();
     expect(getAllByRole('alert').length).toBe(2);
   });
 });

--- a/src/lib/components/ResourceDashboard.svelte
+++ b/src/lib/components/ResourceDashboard.svelte
@@ -22,7 +22,7 @@
     };
 
   onMount(() => {
-    listen<any>('metrics-update', (event) => {
+    const unlisten = listen<any>('metrics-update', (event) => {
       const point: MetricPoint = {
         time: Date.now(),
         memoryMB: Math.round(event.payload.memory_bytes / 1_000_000),
@@ -34,6 +34,10 @@
       };
       metrics = [...metrics, point].slice(-MAX_POINTS);
     });
+
+    return () => {
+      unlisten.then((fn) => fn());
+    };
   });
 </script>
 


### PR DESCRIPTION
## Summary
- ensure ResourceDashboard cleans up event listener
- verify new metrics in ResourceDashboard tests

## Testing
- `bun run test` *(fails: vitest exited with errors)*
- `cargo test` *(fails: could not find glib-2.0)*

------
https://chatgpt.com/codex/tasks/task_e_686a774bc8f48333857cd840d1d317c6