### PR TITLE
Improve connection failure context

### DIFF
--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -93,7 +93,13 @@ async fn connect_with_backoff_error() {
             |_| {},
         )
         .await;
-    assert!(matches!(res, Err(Error::RetriesExceeded { .. })));
+    match res {
+        Err(Error::ConnectionFailed { step, source }) => {
+            assert_eq!(step, "retries_exceeded");
+            assert!(source.contains("e2"));
+        }
+        _ => panic!("expected connection failure"),
+    }
 }
 
 #[tokio::test]
@@ -125,7 +131,10 @@ async fn connect_with_backoff_timeout() {
             |_| {},
         )
         .await;
-    assert!(matches!(res, Err(Error::Timeout)));
+    match res {
+        Err(Error::ConnectionFailed { step, .. }) => assert_eq!(step, "timeout"),
+        _ => panic!("expected timeout error"),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- provide detailed connection error context in `connect_with_backoff`
- adjust tests to expect new `ConnectionFailed` variants

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a774b26a88333a518cd6cd0727a4a