### PR TITLE
Improve error context tests

### DIFF
--- a/docs/SecurityFindings.md
+++ b/docs/SecurityFindings.md
@@ -45,6 +45,14 @@ als 60 gültigen Aufrufen greift der globale Rate Limiter und liefert
 `Error::RateLimitExceeded`. Somit funktionieren die Sitzungsprüfung und das
 Rate‑Limiting wie vorgesehen.
 
+Seit dem letzten Update enthalten auch Verbindungs- und Identitätsfehler eine
+genaue Beschreibung des Schritts, in dem sie auftraten. Beispiele:
+
+```text
+Error::ConnectionFailed { step: "bootstrap", source: "bootstrap: connection lost" }
+Error::Identity { step: "build_circuit", source: "build_circuit: timeout" }
+```
+
 ## Aktueller Stand (2025-07-05)
 
 Aktuell sind keine weiteren offenen Findings bekannt.

--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -97,6 +97,7 @@ async fn connect_with_backoff_error() {
         Err(Error::ConnectionFailed { step, source }) => {
             assert_eq!(step, "retries_exceeded");
             assert!(source.contains("e2"));
+            assert!(source.contains("bootstrap"));
         }
         _ => panic!("expected connection failure"),
     }
@@ -132,7 +133,11 @@ async fn connect_with_backoff_timeout() {
         )
         .await;
     match res {
-        Err(Error::ConnectionFailed { step, .. }) => assert_eq!(step, "timeout"),
+        Err(Error::ConnectionFailed { step, source }) => {
+            assert_eq!(step, "timeout");
+            assert!(source.contains("e1"));
+            assert!(source.contains("bootstrap"));
+        }
         _ => panic!("expected timeout error"),
     }
 }


### PR DESCRIPTION
## Summary
- extend `connect_with_backoff` tests to assert step and source details
- document that connection/identity errors include the step and source fields

## Testing
- `cargo test --quiet` *(fails: glib-2.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a9128e550833384b09bfa80654575