### PR TITLE
Add missing component tests

### DIFF
--- a/src/__tests__/NetworkTools.spec.ts
+++ b/src/__tests__/NetworkTools.spec.ts
@@ -14,4 +14,19 @@ describe('NetworkTools', () => {
     await fireEvent.click(getByText('DNS Lookup'));
     expect(invoke).toHaveBeenNthCalledWith(2, 'dns_lookup', { token: 42, host: 'example.com' });
   });
+
+  it('shows traceroute output', async () => {
+    (invoke as any).mockReset();
+    (invoke as any)
+      .mockResolvedValueOnce(42)
+      .mockResolvedValueOnce(['hop1', 'hop2']);
+
+    const { getByText, getByLabelText, findByText } = render(NetworkTools);
+    const input = getByLabelText('Host') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'example.com' } });
+    await fireEvent.click(getByText('Traceroute'));
+
+    await findByText('Route: hop1 -> hop2');
+    expect(invoke).toHaveBeenNthCalledWith(2, 'traceroute_host', { token: 42, host: 'example.com', maxHops: 8 });
+  });
 });

--- a/src/__tests__/SettingsModal.e2e.spec.ts
+++ b/src/__tests__/SettingsModal.e2e.spec.ts
@@ -135,6 +135,23 @@ describe('SettingsModal persistence', () => {
     expect(select.value).toBe('Default');
   });
 
+  it('calls setBridgePreset action', async () => {
+    const { uiStore } = await import('../lib/stores/uiStore');
+    const spy = vi.spyOn(uiStore.actions, 'setBridgePreset');
+
+    const { getByLabelText, getByRole } = render(SettingsModal, { props: { show: true } });
+    await Promise.resolve();
+
+    await fireEvent.change(getByLabelText('Bridge preset'), { target: { value: 'Default' } });
+    await fireEvent.click(getByRole('button', { name: 'Apply Preset' }));
+
+    expect(spy).toHaveBeenCalledWith('Default', [BRIDGE]);
+
+    const stored = await db.settings.get(1);
+    expect(stored?.bridgePreset).toBe('Default');
+    expect(stored?.bridges).toEqual([BRIDGE]);
+  });
+
   it('selects exit country and persists', async () => {
     const { getByLabelText, getByRole, unmount } = render(SettingsModal, { props: { show: true } });
     await Promise.resolve();


### PR DESCRIPTION
## Summary
- test traceroute output in `NetworkTools`
- verify preset action persistence in `SettingsModal`

## Testing
- `bun test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686a912d36ec833383045fe90e4af1a7