### PR TITLE
Improve worker config handling

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -25,6 +25,6 @@ Dieses Dokument beschreibt, wie du den Beispiel‑Worker aus dem Ordner `cf work
 
 ## Proxy in Torwell84 einrichten
 
-Trage die URL deines Workers in der Anwendung unter **Settings → Worker List** ein und hinterlege das geheime Token im Feld **Worker token**. Alternativ kannst du die Adresse in `src/lib/bridge_presets.json` hinterlegen, damit sie beim ersten Start bereits vorgeschlagen wird.
+Trage die URL deines Workers in der Anwendung unter **Settings → Worker List** ein und hinterlege das geheime Token im Feld **Worker token**. Du kannst mehrere Adressen hinzufügen. Torwell84 probiert sie nacheinander aus und rotiert automatisch weiter, wenn ein Endpunkt nicht erreichbar ist. Alternativ kannst du Adressen in `src/lib/bridge_presets.json` hinterlegen, damit sie beim ersten Start bereits vorgeschlagen werden.
 
-Nach dem Speichern der Einstellungen werden alle über den Worker geleiteten Verbindungen mit dem gesetzten Token authentifiziert.
+Nach dem Speichern der Einstellungen werden alle über den Worker geleiteten Verbindungen mit dem gesetzten Token authentifiziert. Mehrere Worker erhöhen Zuverlässigkeit und ermöglichen eine einfache horizontale Skalierung.

--- a/src-tauri/src/secure_http.rs
+++ b/src-tauri/src/secure_http.rs
@@ -484,28 +484,40 @@ impl SecureHttpClient {
             guard.clone()
         };
 
-        let worker = {
-            let guard = self.worker_urls.lock().await;
-            guard.get(0).cloned()
-        };
-        let resp = if let Some(w) = worker {
-            let mut target = w;
-            let encoded = encode(parsed.as_str());
-            if target.contains('?') {
-                target.push('&');
-            } else {
-                target.push('?');
+        let token = { self.worker_token.lock().await.clone() };
+        let worker_count = { self.worker_urls.lock().await.len() };
+        for _ in 0..worker_count {
+            let worker = { self.worker_urls.lock().await.get(0).cloned() };
+            if let Some(w) = worker {
+                let mut target = w.clone();
+                let encoded = encode(parsed.as_str());
+                if target.contains('?') {
+                    target.push('&');
+                } else {
+                    target.push('?');
+                }
+                target.push_str("url=");
+                target.push_str(&encoded);
+                let mut req = client.get(target);
+                if let Some(tok) = token.as_ref() {
+                    req = req.header("X-Proxy-Token", tok);
+                }
+                match req.send().await {
+                    Ok(resp) => {
+                        self.handle_hsts_header(&resp).await;
+                        return Ok(resp);
+                    }
+                    Err(e) => {
+                        log::warn!("worker {} unreachable: {}", w, e);
+                        let mut guard = self.worker_urls.lock().await;
+                        if !guard.is_empty() {
+                            guard.rotate_left(1);
+                        }
+                    }
+                }
             }
-            target.push_str("url=");
-            target.push_str(&encoded);
-            let mut req = client.get(target);
-            if let Some(tok) = &*self.worker_token.lock().await {
-                req = req.header("X-Proxy-Token", tok);
-            }
-            req.send().await?
-        } else {
-            client.get(parsed.clone()).send().await?
-        };
+        }
+        let resp = client.get(parsed.clone()).send().await?;
         self.handle_hsts_header(&resp).await;
         Ok(resp)
     }
@@ -518,28 +530,40 @@ impl SecureHttpClient {
     /// Send JSON data to an HTTP endpoint using the pinned TLS configuration.
     pub async fn post_json(&self, url: &str, body: &Value) -> reqwest::Result<()> {
         let client = { self.client.lock().await.clone() };
-        let worker = {
-            let guard = self.worker_urls.lock().await;
-            guard.get(0).cloned()
-        };
-        let resp = if let Some(w) = worker {
-            let mut target = w;
-            let encoded = encode(url);
-            if target.contains('?') {
-                target.push('&');
-            } else {
-                target.push('?');
+        let token = { self.worker_token.lock().await.clone() };
+        let worker_count = { self.worker_urls.lock().await.len() };
+        for _ in 0..worker_count {
+            let worker = { self.worker_urls.lock().await.get(0).cloned() };
+            if let Some(w) = worker {
+                let mut target = w.clone();
+                let encoded = encode(url);
+                if target.contains('?') {
+                    target.push('&');
+                } else {
+                    target.push('?');
+                }
+                target.push_str("url=");
+                target.push_str(&encoded);
+                let mut req = client.post(target).json(body);
+                if let Some(tok) = token.as_ref() {
+                    req = req.header("X-Proxy-Token", tok);
+                }
+                match req.send().await {
+                    Ok(resp) => {
+                        self.handle_hsts_header(&resp).await;
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        log::warn!("worker {} unreachable: {}", w, e);
+                        let mut guard = self.worker_urls.lock().await;
+                        if !guard.is_empty() {
+                            guard.rotate_left(1);
+                        }
+                    }
+                }
             }
-            target.push_str("url=");
-            target.push_str(&encoded);
-            let mut req = client.post(target).json(body);
-            if let Some(tok) = &*self.worker_token.lock().await {
-                req = req.header("X-Proxy-Token", tok);
-            }
-            req.send().await?
-        } else {
-            client.post(url).json(body).send().await?
-        };
+        }
+        let resp = client.post(url).json(body).send().await?;
         self.handle_hsts_header(&resp).await;
         Ok(())
     }

--- a/src/lib/stores/uiStore.ts
+++ b/src/lib/stores/uiStore.ts
@@ -250,6 +250,25 @@ function createUIStore() {
       }
     },
 
+    addWorker: async (url: string) => {
+      const current = get({ subscribe });
+      if (!current.settings.workerList.includes(url)) {
+        const workers = [...current.settings.workerList, url];
+        await actions.saveWorkerConfig(workers, current.settings.workerToken);
+      }
+    },
+
+    removeWorker: async (url: string) => {
+      const current = get({ subscribe });
+      const workers = current.settings.workerList.filter((w) => w !== url);
+      await actions.saveWorkerConfig(workers, current.settings.workerToken);
+    },
+
+    setWorkerToken: async (token: string) => {
+      const current = get({ subscribe });
+      await actions.saveWorkerConfig(current.settings.workerList, token);
+    },
+
     setLogLimit: async (limit: number) => {
       try {
         await invoke("set_log_limit", { limit });


### PR DESCRIPTION
## Summary
- add actions for managing proxy workers and token
- redesign worker section in the settings modal
- rotate proxy workers on connection failures
- document scaling when using multiple workers

## Testing
- `bun test` *(fails: Cannot find module '@testing-library/svelte')*
- `cargo test` *(fails: `glib-2.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686aa26f70208333b452d857ecf57fb8