### PR TITLE
Add mobile build checks and artifact docs

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -37,6 +37,7 @@ jobs:
             echo "path=$APK" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: android-apk
           path: ${{ steps.apk.outputs.path }}
@@ -70,6 +71,7 @@ jobs:
             echo "path=$IPA" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: ios-ipa
           path: ${{ steps.ipa.outputs.path }}

--- a/docs/Mobile.md
+++ b/docs/Mobile.md
@@ -33,3 +33,11 @@ A dedicated GitHub workflow (`mobile.yml`) builds the Android and iOS apps. The 
 - `ios-ipa` provides the `.ipa` bundle.
 
 If no binary is produced, the workflow uploads a placeholder archive so the artifact list is always available. Download the desired artifact from the workflow run page to test the mobile build without setting up the full toolchain locally.
+
+## CI Artifacts herunterladen
+
+Die Artefakte kannst du direkt aus dem Mobile-Workflow herunterladen:
+
+1. Rufe in GitHub den gewünschten Workflow-Lauf auf.
+2. Scrolle zum Abschnitt **Artifacts**.
+3. Lade das ZIP `android-apk` oder `ios-ipa` herunter.

--- a/mobile/scripts/build_android.sh
+++ b/mobile/scripts/build_android.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 set -e
+
+check_dep() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' is required but not installed." >&2
+    exit 1
+  fi
+}
+
+for cmd in bun cargo npx; do
+  check_dep "$cmd"
+done
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
 

--- a/mobile/scripts/build_ios.sh
+++ b/mobile/scripts/build_ios.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 set -e
+
+check_dep() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' is required but not installed." >&2
+    exit 1
+  fi
+}
+
+for cmd in bun cargo npx; do
+  check_dep "$cmd"
+done
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
 


### PR DESCRIPTION
## Summary
- validate required dependencies in Android/iOS build scripts
- always upload APK/IPA in the CI mobile workflow
- document how to download CI artifacts

## Testing
- `bun test` *(fails: `vi.mock` is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_686aa270970483339d1a4b567f831efd