### PR TITLE
Add CPU & network charts

### DIFF
--- a/src/__tests__/ResourceDashboard.spec.ts
+++ b/src/__tests__/ResourceDashboard.spec.ts
@@ -1,20 +1,21 @@
-import { render } from '@testing-library/svelte';
-import { vi, describe, it, expect } from 'vitest';
-import { tick } from 'svelte';
+import { render } from "@testing-library/svelte";
+import { vi, describe, it, expect } from "vitest";
+import { tick } from "svelte";
 
 let metricsCallback: (e: any) => void = () => {};
-vi.mock('@tauri-apps/api/event', () => ({
+vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn((ev: string, cb: any) => {
-    if (ev === 'metrics-update') metricsCallback = cb;
-  })
+    if (ev === "metrics-update") metricsCallback = cb;
+    return Promise.resolve(() => {});
+  }),
 }));
 
-import ResourceDashboard from '../lib/components/ResourceDashboard.svelte';
+import ResourceDashboard from "../lib/components/ResourceDashboard.svelte";
 
-describe('ResourceDashboard', () => {
-  it('updates metrics and shows warnings', async () => {
-    const { getByText, getAllByRole } = render(ResourceDashboard);
-
+describe("ResourceDashboard", () => {
+  it("updates metrics and shows warnings", async () => {
+    const { getByText, getAllByRole, container } = render(ResourceDashboard);
+    await tick();
     metricsCallback({
       payload: {
         memory_bytes: 1500_000_000,
@@ -28,13 +29,15 @@ describe('ResourceDashboard', () => {
       },
     });
     await tick();
+    await tick();
 
-    expect(getByText('Memory: 1500 MB')).toBeInTheDocument();
-    expect(getByText('Circuits: 25')).toBeInTheDocument();
-    expect(getByText('Avg build: 50 ms')).toBeInTheDocument();
-    expect(getByText('Failures: 3')).toBeInTheDocument();
-    expect(getByText('CPU: 12.5 %')).toBeInTheDocument();
-    expect(getByText('Network: 2048 B/s')).toBeInTheDocument();
-    expect(getAllByRole('alert').length).toBe(2);
+    expect(getByText(/Memory: 1500 MB/)).toBeInTheDocument();
+    expect(getByText(/Circuits: 25/)).toBeInTheDocument();
+    expect(getByText(/Avg build: 50 ms/)).toBeInTheDocument();
+    expect(getByText(/Failures: 3/)).toBeInTheDocument();
+    expect(getByText(/CPU: 12.5 %/)).toBeInTheDocument();
+    expect(getByText(/Network: 2048 B\/s/)).toBeInTheDocument();
+    expect(getAllByRole("alert").length).toBe(2);
+    expect(container).toMatchSnapshot();
   });
 });

--- a/src/lib/components/ResourceDashboard.svelte
+++ b/src/lib/components/ResourceDashboard.svelte
@@ -7,8 +7,28 @@
   let metrics: MetricPoint[] = [];
   const MAX_POINTS = 30;
 
+  const width = 120;
+  const height = 40;
+
+  function buildPath(data: MetricPoint[], field: keyof MetricPoint): string {
+    if (data.length === 0) return "";
+    const maxVal = Math.max(...data.map((d) => d[field] as number), 1);
+    const step = width / Math.max(data.length - 1, 1);
+    let d = `M0 ${height}`;
+    data.forEach((pt, idx) => {
+      const x = idx * step;
+      const y = height - ((pt[field] as number) / maxVal) * height;
+      d += ` L${x} ${y}`;
+    });
+    d += ` L${width} ${height} Z`;
+    return d;
+  }
+
   const MAX_MEMORY_MB = 1024;
   const MAX_CIRCUITS = 20;
+
+  $: cpuPath = buildPath(metrics, 'cpuPercent');
+  $: networkPath = buildPath(metrics, 'networkBytes');
 
   $: latest =
     metrics[metrics.length - 1] ?? {
@@ -69,9 +89,19 @@
   <div class="flex gap-4">
     <div class="flex-1">
       <p class="text-sm text-white">CPU: {latest.cpuPercent.toFixed(1)} %</p>
+      <svg {width} {height} class="text-yellow-400" aria-label="CPU usage chart" role="img">
+        {#if cpuPath}
+          <path d={cpuPath} fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1" />
+        {/if}
+      </svg>
     </div>
     <div class="flex-1">
       <p class="text-sm text-white">Network: {latest.networkBytes} B/s</p>
+      <svg {width} {height} class="text-purple-400" aria-label="Network usage chart" role="img">
+        {#if networkPath}
+          <path d={networkPath} fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1" />
+        {/if}
+      </svg>
     </div>
   </div>
   <MetricsChart {metrics} />

--- a/src/lib/components/TorChain.svelte
+++ b/src/lib/components/TorChain.svelte
@@ -6,7 +6,8 @@
 	export let middleCountry = 'Germany';
 	export let exitCountry = 'Germany';
 	export let isActive = true;
-	export let cloudflareEnabled = false;
+        import { uiStore } from '$lib/stores/uiStore';
+        $: cloudflareEnabled = $uiStore.cloudflareEnabled;
 
 	// Node data with IPs and names
         export let nodeData: { nickname: string; ip_address: string; country: string }[] = [];
@@ -22,8 +23,6 @@
 	};
 
         const countries = ['Germany','France','Belgium','Switzerland','Liechtenstein','Luxembourg','Austria','Spain','Italy','Portugal','Russia','Romania','Turkey','UK','USA','Canada','Mexico','Brazil','Argentina','Japan','China','Antarctica'];
-
-        import { uiStore } from '$lib/stores/uiStore';
 
         const exitCountryOptions = [
                 { code: 'DE', name: 'Germany' },

--- a/src/lib/stores/uiStore.ts
+++ b/src/lib/stores/uiStore.ts
@@ -16,6 +16,7 @@ type AppSettings = {
 type UIState = {
   isLogsModalOpen: boolean;
   isSettingsModalOpen: boolean;
+  cloudflareEnabled: boolean;
   settings: AppSettings;
   error: string | null;
 };
@@ -24,6 +25,7 @@ function createUIStore() {
   const { subscribe, update, set } = writable<UIState>({
     isLogsModalOpen: false,
     isSettingsModalOpen: false,
+    cloudflareEnabled: false,
     settings: {
       workerList: ["worker1.example.com", "worker2.example.com"], // Default values
       torrcConfig: "# Default torrc config\n",
@@ -55,6 +57,9 @@ function createUIStore() {
       update((state) => ({ ...state, isSettingsModalOpen: true })),
     closeSettingsModal: () =>
       update((state) => ({ ...state, isSettingsModalOpen: false })),
+
+    setCloudflareEnabled: (val: boolean) =>
+      update((state) => ({ ...state, cloudflareEnabled: val })),
 
     loadSettings: async () => {
       try {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -128,7 +128,6 @@
       isActive={$torStore.status === "CONNECTED"}
       nodeData={activeCircuit}
       isolatedCircuits={isolatedCircuits}
-      cloudflareEnabled={false}
     />
 
     <ActionCard


### PR DESCRIPTION
## Summary
- add cpu and network charts in ResourceDashboard
- read cloudflare flag from ui store and grey out card when disabled
- expose cloudflare flag in uiStore
- update TorChain usage
- extend ResourceDashboard tests with snapshot

## Testing
- `npx vitest run src/__tests__/ResourceDashboard.spec.ts` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_686aa27105508333bb04f49e94eae366