### PR TITLE
Add HSM configuration

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -28,3 +28,7 @@ Dieses Dokument beschreibt, wie du den Beispiel‑Worker aus dem Ordner `cf work
 Trage die URL deines Workers in der Anwendung unter **Settings → Worker List** ein und hinterlege das geheime Token im Feld **Worker token**. Du kannst mehrere Adressen hinzufügen. Torwell84 probiert sie nacheinander aus und rotiert automatisch weiter, wenn ein Endpunkt nicht erreichbar ist. Alternativ kannst du Adressen in `src/lib/bridge_presets.json` hinterlegen, damit sie beim ersten Start bereits vorgeschlagen werden.
 
 Nach dem Speichern der Einstellungen werden alle über den Worker geleiteten Verbindungen mit dem gesetzten Token authentifiziert. Mehrere Worker erhöhen Zuverlässigkeit und ermöglichen eine einfache horizontale Skalierung.
+
+## Hardware Security Module verwenden
+
+Unter **Settings → HSM Configuration** kannst du den Pfad zur PKCS#11‑Bibliothek und den Slot angeben. Nach dem Speichern werden die Werte im Backend übernommen und für neue TLS‑Verbindungen genutzt.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -274,6 +274,22 @@ pub async fn set_worker_config(
 }
 
 #[tauri::command]
+pub async fn set_hsm_config(
+    state: State<'_, AppState>,
+    lib: Option<String>,
+    slot: Option<u64>,
+) -> Result<()> {
+    check_api_rate()?;
+    state
+        .http_client
+        .set_hsm_config(lib, slot)
+        .await
+        .map_err(|e| Error::Io(e.to_string()))?
+        ;
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn list_bridge_presets() -> Result<Vec<BridgePreset>> {
     crate::tor_manager::load_default_bridge_presets()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,6 +155,7 @@ pub fn run() {
             commands::set_exit_country,
             commands::set_bridges,
             commands::set_worker_config,
+            commands::set_hsm_config,
             commands::list_bridge_presets,
             commands::get_traffic_stats,
             commands::get_metrics,

--- a/src-tauri/src/secure_http.rs
+++ b/src-tauri/src/secure_http.rs
@@ -368,6 +368,25 @@ impl SecureHttpClient {
         *self.worker_token.lock().await = token;
     }
 
+    /// Update HSM library path and slot then reload TLS configuration
+    pub async fn set_hsm_config(
+        &self,
+        lib: Option<String>,
+        slot: Option<u64>,
+    ) -> anyhow::Result<()> {
+        if let Some(l) = lib {
+            std::env::set_var("TORWELL_HSM_LIB", &l);
+        } else {
+            std::env::remove_var("TORWELL_HSM_LIB");
+        }
+        if let Some(s) = slot {
+            std::env::set_var("TORWELL_HSM_SLOT", s.to_string());
+        } else {
+            std::env::remove_var("TORWELL_HSM_SLOT");
+        }
+        self.reload_certificates().await
+    }
+
     async fn emit_warning(&self, msg: String) {
         if let Some(cb) = self.warning_cb.lock().await.as_ref() {
             cb(msg);

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -29,6 +29,8 @@
   let workerToken = "";
   let maxLogLines = 1000;
   let exitCountry: string | null = null;
+  let hsmLib: string | null = null;
+  let hsmSlot: number | null = null;
   // import TorrcEditorModal from './TorrcEditorModal.svelte';
 
   export let show: boolean;
@@ -49,6 +51,8 @@
     workerToken = $uiStore.settings.workerToken;
     maxLogLines = $uiStore.settings.maxLogLines;
     exitCountry = $uiStore.settings.exitCountry ?? null;
+    hsmLib = $uiStore.settings.hsm_lib;
+    hsmSlot = $uiStore.settings.hsm_slot;
     uiStore.actions.setExitCountry(exitCountry);
     if (availableBridges.length === 0) loadPresets();
     tick().then(() => closeButton && closeButton.focus());
@@ -113,6 +117,11 @@
 
   function saveExitCountry() {
     uiStore.actions.setExitCountry(exitCountry);
+  }
+
+  function saveHsm() {
+    const slotNum = hsmSlot === null ? null : Number(hsmSlot);
+    uiStore.actions.saveHsmConfig(hsmLib, isNaN(slotNum as number) ? null : slotNum);
   }
 
   function applyPreset() {
@@ -332,6 +341,34 @@
             class="text-sm py-2 px-4 mt-2 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
             on:click={saveLogLimit}
             aria-label="Save log limit"
+          >
+            Save
+          </button>
+        </div>
+
+        <div class="mb-8">
+          <h3 class="text-lg font-semibold mb-4 border-b border-white/10 pb-2">
+            HSM Configuration
+          </h3>
+          <input
+            type="text"
+            class="w-full bg-black/50 rounded border border-white/20 p-2 text-sm mb-2"
+            placeholder="/usr/lib/softhsm/libsofthsm2.so"
+            bind:value={hsmLib}
+            aria-label="HSM library path"
+          />
+          <input
+            type="number"
+            min="0"
+            class="w-full bg-black/50 rounded border border-white/20 p-2 text-sm"
+            placeholder="0"
+            bind:value={hsmSlot}
+            aria-label="HSM slot"
+          />
+          <button
+            class="text-sm py-2 px-4 mt-2 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
+            on:click={saveHsm}
+            aria-label="Save HSM configuration"
           >
             Save
           </button>


### PR DESCRIPTION
## Summary
- support new hsm_lib and hsm_slot fields in SettingsModal
- persist HSM configuration in IndexedDB and backend
- expose `set_hsm_config` command and reload certificates
- document HSM usage in user docs

## Testing
- `bun run check` *(fails: `svelte-kit` not found)*
- `bun run lint:a11y` *(fails: `svelte-kit` not found)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 development files missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ab09037848333821c8a3a32770af2