### PR TITLE
Implement certificate update backoff

### DIFF
--- a/src-tauri/src/secure_http.rs
+++ b/src-tauri/src/secure_http.rs
@@ -216,6 +216,7 @@ pub struct SecureHttpClient {
     warning_cb: Arc<Mutex<Option<Box<dyn Fn(String) + Send + Sync>>>>,
     pending_warnings: Arc<Mutex<Vec<String>>>,
     update_failures: Arc<Mutex<u32>>,
+    update_backoff: Arc<Mutex<Option<Duration>>>,
     worker_urls: Arc<Mutex<Vec<String>>>,
     worker_token: Arc<Mutex<Option<String>>>,
 }
@@ -230,6 +231,7 @@ impl Clone for SecureHttpClient {
             warning_cb: self.warning_cb.clone(),
             pending_warnings: self.pending_warnings.clone(),
             update_failures: self.update_failures.clone(),
+            update_backoff: self.update_backoff.clone(),
             worker_urls: self.worker_urls.clone(),
             worker_token: self.worker_token.clone(),
         }
@@ -338,6 +340,7 @@ impl SecureHttpClient {
             warning_cb: Arc::new(Mutex::new(None)),
             pending_warnings: Arc::new(Mutex::new(Vec::new())),
             update_failures: Arc::new(Mutex::new(0)),
+            update_backoff: Arc::new(Mutex::new(None)),
             worker_urls: Arc::new(Mutex::new(Vec::new())),
             worker_token: Arc::new(Mutex::new(None)),
         })
@@ -595,6 +598,7 @@ impl SecureHttpClient {
                 Ok(_) => {
                     let mut cnt = self.update_failures.lock().await;
                     *cnt = 0;
+                    *self.update_backoff.lock().await = None;
                     return Ok(());
                 }
                 Err(e) => {
@@ -608,6 +612,7 @@ impl SecureHttpClient {
             if *cnt >= 3 {
                 self.emit_warning(format!("{} consecutive certificate update failures", *cnt))
                     .await;
+                *self.update_backoff.lock().await = Some(Duration::from_secs(60 * 60));
             }
         }
         Err(anyhow::anyhow!("all certificate update attempts failed"))
@@ -619,7 +624,11 @@ impl SecureHttpClient {
                 if let Err(e) = self.update_certificates_from(&urls).await {
                     log::error!("certificate update failed: {}", e);
                 }
-                tokio::time::sleep(interval).await;
+                let extra = {
+                    let mut guard = self.update_backoff.lock().await;
+                    guard.take().unwrap_or_else(|| Duration::from_secs(0))
+                };
+                tokio::time::sleep(interval + extra).await;
             }
         });
     }

--- a/src-tauri/tests/cert_rotation_tests.rs
+++ b/src-tauri/tests/cert_rotation_tests.rs
@@ -1,10 +1,15 @@
 use httpmock::prelude::*;
 use std::fs;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
+use tokio::sync::Mutex;
 
 use torwell84::secure_http::SecureHttpClient;
+use torwell84::session::SessionManager;
+use torwell84::state::AppState;
+use torwell84::tor_manager::TorManager;
 
 const CA_PEM: &str = include_str!("../tests_data/ca.pem");
 const NEW_CERT: &str = include_str!("../tests_data/new_cert.pem");
@@ -32,7 +37,9 @@ async fn schedule_updates_rotates_certificate() {
     let client = Arc::new(SecureHttpClient::new(&cert_path).unwrap());
     assert!(client.get_text(&server.url("/hello")).await.is_ok());
 
-    client.clone().schedule_updates(vec![server.url("/cert.pem")], Duration::from_millis(50));
+    client
+        .clone()
+        .schedule_updates(vec![server.url("/cert.pem")], Duration::from_millis(50));
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -41,4 +48,62 @@ async fn schedule_updates_rotates_certificate() {
 
     let updated = fs::read_to_string(&cert_path).unwrap();
     assert_eq!(updated, NEW_CERT);
+}
+
+#[tokio::test]
+async fn tray_warning_after_failed_updates() {
+    let server = MockServer::start_async().await;
+    server
+        .mock_async(|when, then| {
+            when.method(GET).path("/cert.pem");
+            then.status(500);
+        })
+        .await;
+
+    let dir = tempdir().unwrap();
+    let cert_path = dir.path().join("pinned.pem");
+    fs::write(&cert_path, CA_PEM).unwrap();
+    let client = Arc::new(SecureHttpClient::new(&cert_path).unwrap());
+
+    for _ in 0..3 {
+        let _ = client
+            .update_certificates_from(&[server.url("/cert.pem")])
+            .await;
+    }
+
+    let mut app = tauri::test::mock_app();
+    let state = torwell84::state::AppState {
+        tor_manager: Arc::new(torwell84::tor_manager::TorManager::new()),
+        http_client: client.clone(),
+        log_file: cert_path.clone(),
+        log_lock: Arc::new(tokio::sync::Mutex::new(())),
+        retry_counter: Arc::new(tokio::sync::Mutex::new(0)),
+        max_log_lines: Arc::new(tokio::sync::Mutex::new(1000)),
+        memory_usage: Arc::new(tokio::sync::Mutex::new(0)),
+        circuit_count: Arc::new(tokio::sync::Mutex::new(0)),
+        oldest_circuit_age: Arc::new(tokio::sync::Mutex::new(0)),
+        latency_ms: Arc::new(tokio::sync::Mutex::new(0)),
+        cpu_usage: Arc::new(tokio::sync::Mutex::new(0.0)),
+        network_throughput: Arc::new(tokio::sync::Mutex::new(0)),
+        max_memory_mb: 1024,
+        max_circuits: 20,
+        session: torwell84::session::SessionManager::new(Duration::from_secs(60)),
+        app_handle: Arc::new(tokio::sync::Mutex::new(None)),
+        tray_warning: Arc::new(tokio::sync::Mutex::new(None)),
+    };
+    app.manage(state);
+    let state = app.state::<torwell84::state::AppState>();
+    state.register_handle(app.handle()).await;
+
+    tokio::time::pause();
+    state.clone().start_metrics_task(app.handle());
+    tokio::time::advance(Duration::from_secs(31)).await;
+
+    assert!(state
+        .tray_warning
+        .lock()
+        .await
+        .as_ref()
+        .unwrap()
+        .contains("certificate update"));
 }


### PR DESCRIPTION
## Summary
- warn and delay TLS certificate updates for an hour after three failures
- surface certificate update failures in the tray menu
- test warning flag when updates repeatedly fail

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features` *(fails: could not compile `torwell84` due to missing system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ab09147808333b8f271938e89d02f