### PR TITLE
Update mobile build scripts

### DIFF
--- a/docs/Mobile.md
+++ b/docs/Mobile.md
@@ -16,7 +16,14 @@ The Svelte frontend is reused by pointing `webDir` to the compiled web assets.
    Each task performs the following:
    - `bun run build` generates the web assets in `build/`.
    - `cargo build --release --manifest-path src-tauri/Cargo.toml --features mobile` compiles the Rust backend so the HTTP bridge is included.
-   - The Capacitor CLI then syncs and builds the native project.
+   - The Capacitor CLI then copies the assets and builds the native project.
+
+3. To create the final application packages manually run:
+
+   ```bash
+   ./mobile/scripts/build_android.sh   # generates the APK
+   ./mobile/scripts/build_ios.sh       # generates the IPA (macOS required)
+   ```
 
 ## IPC Bridge
 

--- a/mobile/scripts/build_android.sh
+++ b/mobile/scripts/build_android.sh
@@ -25,5 +25,5 @@ cargo build --release --manifest-path "$ROOT_DIR/src-tauri/Cargo.toml" --feature
 # Build the Android app using Capacitor
 cd "$SCRIPT_DIR/.."
 bun install
-npx cap sync android
+npx cap copy android
 npx cap build android

--- a/mobile/scripts/build_ios.sh
+++ b/mobile/scripts/build_ios.sh
@@ -25,5 +25,5 @@ cargo build --release --manifest-path "$ROOT_DIR/src-tauri/Cargo.toml" --feature
 # Build the iOS app using Capacitor
 cd "$SCRIPT_DIR/.."
 bun install
-npx cap sync ios
+npx cap copy ios
 npx cap build ios


### PR DESCRIPTION
## Summary
- use `capacitor copy` instead of `sync` in Android/iOS build scripts
- document manual APK/IPA creation commands

## Testing
- `bun install`
- `bun run test` *(fails: TestingLibraryElementError, NotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686ab0923ddc8333b2903481cef2220e