### PR TITLE
Improve modal sync tests and Cloudflare UI

### DIFF
--- a/src/__tests__/SettingsModal.e2e.spec.ts
+++ b/src/__tests__/SettingsModal.e2e.spec.ts
@@ -1,29 +1,29 @@
-import { render, fireEvent } from '@testing-library/svelte';
-import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
-import 'fake-indexeddb/auto';
+import { render, fireEvent } from "@testing-library/svelte";
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import "fake-indexeddb/auto";
 
-vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
-vi.mock('@tauri-apps/api/tauri', () => {
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn() }));
+vi.mock("@tauri-apps/api/tauri", () => {
   const store = new Map<string, any>();
   return {
     invoke: vi.fn((cmd: string, args?: any) => {
-      if (cmd === 'get_secure_key') {
-        return Promise.resolve(store.get('aes-key') ?? null);
+      if (cmd === "get_secure_key") {
+        return Promise.resolve(store.get("aes-key") ?? null);
       }
-      if (cmd === 'set_secure_key') {
-        store.set('aes-key', args.value);
+      if (cmd === "set_secure_key") {
+        store.set("aes-key", args.value);
         return Promise.resolve();
       }
-      if (cmd === 'set_bridges') {
-        store.set('bridges', args.bridges);
+      if (cmd === "set_bridges") {
+        store.set("bridges", args.bridges);
         return Promise.resolve();
       }
-      if (cmd === 'set_exit_country') {
-        store.set('exitCountry', args.country);
+      if (cmd === "set_exit_country") {
+        store.set("exitCountry", args.country);
         return Promise.resolve();
       }
-      if (cmd === 'set_log_limit') {
-        store.set('logLimit', args.limit);
+      if (cmd === "set_log_limit") {
+        store.set("logLimit", args.limit);
         return Promise.resolve();
       }
       return Promise.resolve(null);
@@ -31,159 +31,238 @@ vi.mock('@tauri-apps/api/tauri', () => {
   };
 });
 
-import SettingsModal from '../lib/components/SettingsModal.svelte';
-import { db } from '../lib/database';
+import SettingsModal from "../lib/components/SettingsModal.svelte";
+import { db } from "../lib/database";
 
 const BRIDGE =
-  'Bridge obfs4 192.0.2.1:443 0123456789ABCDEF0123456789ABCDEF01234567 cert=AAAA iat-mode=0';
+  "Bridge obfs4 192.0.2.1:443 0123456789ABCDEF0123456789ABCDEF01234567 cert=AAAA iat-mode=0";
 const PRESETS = {
   bridges: [BRIDGE],
-  presets: [
-    { name: 'Default', bridges: [BRIDGE] }
-  ],
-  exitCountries: [{ code: 'DE', name: 'Germany' }],
+  presets: [{ name: "Default", bridges: [BRIDGE] }],
+  exitCountries: [{ code: "DE", name: "Germany" }],
 };
 
-describe('SettingsModal persistence', () => {
+describe("SettingsModal persistence", () => {
   beforeEach(async () => {
     await db.delete();
     await db.open();
-    vi.stubGlobal('fetch', vi.fn(async () => ({ json: async () => PRESETS } as any)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ json: async () => PRESETS }) as any),
+    );
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('saves and reloads settings', async () => {
-    const { getByLabelText, getByRole, unmount } = render(SettingsModal, { props: { show: true } });
+  it("saves and reloads settings", async () => {
+    const { getByLabelText, getByRole, unmount } = render(SettingsModal, {
+      props: { show: true },
+    });
     await Promise.resolve();
 
     await fireEvent.click(getByLabelText(BRIDGE));
-    await fireEvent.change(getByLabelText('Exit country'), { target: { value: 'DE' } });
-    await fireEvent.input(getByLabelText('Maximum log lines'), { target: { value: '123' } });
-    await fireEvent.click(getByRole('button', { name: 'Apply bridge selection' }));
-    await fireEvent.click(getByRole('button', { name: 'Save exit country' }));
-    await fireEvent.click(getByRole('button', { name: 'Save log limit' }));
+    await fireEvent.change(getByLabelText("Exit country"), {
+      target: { value: "DE" },
+    });
+    await fireEvent.input(getByLabelText("Maximum log lines"), {
+      target: { value: "123" },
+    });
+    await fireEvent.click(
+      getByRole("button", { name: "Apply bridge selection" }),
+    );
+    await fireEvent.click(getByRole("button", { name: "Save exit country" }));
+    await fireEvent.click(getByRole("button", { name: "Save log limit" }));
 
     unmount();
 
     const stored = await db.settings.get(1);
     expect(stored?.bridges).toContain(BRIDGE);
-    expect(stored?.exitCountry).toBe('DE');
+    expect(stored?.exitCountry).toBe("DE");
     expect(stored?.maxLogLines).toBe(123);
 
-    const { getByLabelText: getByLabelText2 } = render(SettingsModal, { props: { show: true } });
-    const input = getByLabelText2('Maximum log lines') as HTMLInputElement;
-    const select = getByLabelText2('Exit country') as HTMLSelectElement;
-    expect(input.value).toBe('123');
-    expect(select.value).toBe('DE');
+    const { getByLabelText: getByLabelText2 } = render(SettingsModal, {
+      props: { show: true },
+    });
+    const input = getByLabelText2("Maximum log lines") as HTMLInputElement;
+    const select = getByLabelText2("Exit country") as HTMLSelectElement;
+    expect(input.value).toBe("123");
+    expect(select.value).toBe("DE");
   });
 
-  it('applies bridges via store and backend', async () => {
-  const { getByLabelText, getByRole } = render(SettingsModal, { props: { show: true } });
-  await Promise.resolve();
-
-  await fireEvent.click(getByLabelText(BRIDGE));
-  await fireEvent.click(getByRole('button', { name: 'Apply bridge selection' }));
-
-  const { uiStore } = await import('../lib/stores/uiStore');
-  await Promise.resolve();
-
-  const { get } = await import('svelte/store');
-  expect(get(uiStore).settings.bridges).toContain(BRIDGE);
-
-  const { invoke } = await import('@tauri-apps/api/tauri');
-  expect(invoke).toHaveBeenCalledWith('set_bridges', { bridges: [BRIDGE] });
-
-  const stored = await db.settings.get(1);
-  expect(stored?.bridges).toContain(BRIDGE);
-});
-
-  it('loads and saves bridge selection', async () => {
-    const { getByLabelText, getByRole, unmount } = render(SettingsModal, { props: { show: true } });
+  it("applies bridges via store and backend", async () => {
+    const { getByLabelText, getByRole } = render(SettingsModal, {
+      props: { show: true },
+    });
     await Promise.resolve();
 
     await fireEvent.click(getByLabelText(BRIDGE));
-    await fireEvent.click(getByRole('button', { name: 'Apply bridge selection' }));
+    await fireEvent.click(
+      getByRole("button", { name: "Apply bridge selection" }),
+    );
 
-    unmount();
-
-    const stored = await db.settings.get(1);
-  expect(stored?.bridges).toEqual([BRIDGE]);
-
-  const { getByLabelText: getAgain } = render(SettingsModal, { props: { show: true } });
-  const bridgeCheckbox = getAgain(BRIDGE) as HTMLInputElement;
-  expect(bridgeCheckbox.checked).toBe(true);
-  });
-
-  it('applies preset and persists selection', async () => {
-    const { getByLabelText, getByText, getByRole, unmount } = render(SettingsModal, { props: { show: true } });
+    const { uiStore } = await import("../lib/stores/uiStore");
     await Promise.resolve();
 
-    await fireEvent.change(getByLabelText('Bridge preset'), { target: { value: 'Default' } });
-    await fireEvent.click(getByRole('button', { name: 'Apply Preset' }));
+    const { get } = await import("svelte/store");
+    expect(get(uiStore).settings.bridges).toContain(BRIDGE);
+
+    const { invoke } = await import("@tauri-apps/api/tauri");
+    expect(invoke).toHaveBeenCalledWith("set_bridges", { bridges: [BRIDGE] });
+
+    const stored = await db.settings.get(1);
+    expect(stored?.bridges).toContain(BRIDGE);
+  });
+
+  it("loads and saves bridge selection", async () => {
+    const { getByLabelText, getByRole, unmount } = render(SettingsModal, {
+      props: { show: true },
+    });
+    await Promise.resolve();
+
+    await fireEvent.click(getByLabelText(BRIDGE));
+    await fireEvent.click(
+      getByRole("button", { name: "Apply bridge selection" }),
+    );
 
     unmount();
 
     const stored = await db.settings.get(1);
-    expect(stored?.bridgePreset).toBe('Default');
     expect(stored?.bridges).toEqual([BRIDGE]);
 
-    const { getByLabelText: again } = render(SettingsModal, { props: { show: true } });
-    const select = again('Bridge preset') as HTMLSelectElement;
-    expect(select.value).toBe('Default');
+    const { getByLabelText: getAgain } = render(SettingsModal, {
+      props: { show: true },
+    });
+    const bridgeCheckbox = getAgain(BRIDGE) as HTMLInputElement;
+    expect(bridgeCheckbox.checked).toBe(true);
   });
 
-  it('calls setBridgePreset action', async () => {
-    const { uiStore } = await import('../lib/stores/uiStore');
-    const spy = vi.spyOn(uiStore.actions, 'setBridgePreset');
-
-    const { getByLabelText, getByRole } = render(SettingsModal, { props: { show: true } });
+  it("applies preset and persists selection", async () => {
+    const { getByLabelText, getByText, getByRole, unmount } = render(
+      SettingsModal,
+      { props: { show: true } },
+    );
     await Promise.resolve();
 
-    await fireEvent.change(getByLabelText('Bridge preset'), { target: { value: 'Default' } });
-    await fireEvent.click(getByRole('button', { name: 'Apply Preset' }));
-
-    expect(spy).toHaveBeenCalledWith('Default', [BRIDGE]);
-
-    const stored = await db.settings.get(1);
-    expect(stored?.bridgePreset).toBe('Default');
-    expect(stored?.bridges).toEqual([BRIDGE]);
-  });
-
-  it('selects exit country and persists', async () => {
-    const { getByLabelText, getByRole, unmount } = render(SettingsModal, { props: { show: true } });
-    await Promise.resolve();
-
-    await fireEvent.change(getByLabelText('Exit country'), { target: { value: 'DE' } });
-    await fireEvent.click(getByRole('button', { name: 'Save exit country' }));
+    await fireEvent.change(getByLabelText("Bridge preset"), {
+      target: { value: "Default" },
+    });
+    await fireEvent.click(getByRole("button", { name: "Apply Preset" }));
 
     unmount();
 
     const stored = await db.settings.get(1);
-    expect(stored?.exitCountry).toBe('DE');
+    expect(stored?.bridgePreset).toBe("Default");
+    expect(stored?.bridges).toEqual([BRIDGE]);
 
-    const { getByLabelText: get2 } = render(SettingsModal, { props: { show: true } });
-    const select = get2('Exit country') as HTMLSelectElement;
-    expect(select.value).toBe('DE');
-
-    const { invoke } = await import('@tauri-apps/api/tauri');
-    expect(invoke).toHaveBeenCalledWith('set_exit_country', { country: 'DE' });
+    const { getByLabelText: again } = render(SettingsModal, {
+      props: { show: true },
+    });
+    const select = again("Bridge preset") as HTMLSelectElement;
+    expect(select.value).toBe("Default");
   });
 
-  it('calls setLogLimit action', async () => {
-    const { uiStore } = await import('../lib/stores/uiStore');
-    const spy = vi.spyOn(uiStore.actions, 'setLogLimit');
+  it("calls setBridgePreset action", async () => {
+    const { uiStore } = await import("../lib/stores/uiStore");
+    const spy = vi.spyOn(uiStore.actions, "setBridgePreset");
 
-    const { getByLabelText, getByRole } = render(SettingsModal, { props: { show: true } });
+    const { getByLabelText, getByRole } = render(SettingsModal, {
+      props: { show: true },
+    });
+    await Promise.resolve();
 
-    await fireEvent.input(getByLabelText('Maximum log lines'), { target: { value: '200' } });
-    await fireEvent.click(getByRole('button', { name: 'Save log limit' }));
+    await fireEvent.change(getByLabelText("Bridge preset"), {
+      target: { value: "Default" },
+    });
+    await fireEvent.click(getByRole("button", { name: "Apply Preset" }));
+
+    expect(spy).toHaveBeenCalledWith("Default", [BRIDGE]);
+
+    const stored = await db.settings.get(1);
+    expect(stored?.bridgePreset).toBe("Default");
+    expect(stored?.bridges).toEqual([BRIDGE]);
+  });
+
+  it("selects exit country and persists", async () => {
+    const { getByLabelText, getByRole, unmount } = render(SettingsModal, {
+      props: { show: true },
+    });
+    await Promise.resolve();
+
+    await fireEvent.change(getByLabelText("Exit country"), {
+      target: { value: "DE" },
+    });
+    await fireEvent.click(getByRole("button", { name: "Save exit country" }));
+
+    unmount();
+
+    const stored = await db.settings.get(1);
+    expect(stored?.exitCountry).toBe("DE");
+
+    const { getByLabelText: get2 } = render(SettingsModal, {
+      props: { show: true },
+    });
+    const select = get2("Exit country") as HTMLSelectElement;
+    expect(select.value).toBe("DE");
+
+    const { invoke } = await import("@tauri-apps/api/tauri");
+    expect(invoke).toHaveBeenCalledWith("set_exit_country", { country: "DE" });
+  });
+
+  it("calls setLogLimit action", async () => {
+    const { uiStore } = await import("../lib/stores/uiStore");
+    const spy = vi.spyOn(uiStore.actions, "setLogLimit");
+
+    const { getByLabelText, getByRole } = render(SettingsModal, {
+      props: { show: true },
+    });
+
+    await fireEvent.input(getByLabelText("Maximum log lines"), {
+      target: { value: "200" },
+    });
+    await fireEvent.click(getByRole("button", { name: "Save log limit" }));
 
     expect(spy).toHaveBeenCalledWith(200);
 
     const stored = await db.settings.get(1);
     expect(stored?.maxLogLines).toBe(200);
+  });
+
+  it("retains worker list and exit country across multiple openings", async () => {
+    const { getByLabelText, getByRole, component } = render(SettingsModal, {
+      props: { show: true },
+    });
+    await Promise.resolve();
+
+    await fireEvent.input(getByLabelText("New worker URL"), {
+      target: { value: "https://w3" },
+    });
+    await fireEvent.click(getByRole("button", { name: "Add worker" }));
+    await fireEvent.click(getByRole("button", { name: "Save worker list" }));
+    await fireEvent.change(getByLabelText("Exit country"), {
+      target: { value: "DE" },
+    });
+    await fireEvent.click(getByRole("button", { name: "Save exit country" }));
+
+    await component.$set({ show: false });
+    await component.$set({ show: true });
+
+    const input1 = getByLabelText("Worker URL 0") as HTMLInputElement;
+    const select1 = getByLabelText("Exit country") as HTMLSelectElement;
+    expect(input1.value).toBe("https://w3");
+    expect(select1.value).toBe("DE");
+
+    await component.$set({ show: false });
+    await component.$set({ show: true });
+
+    const input2 = getByLabelText("Worker URL 0") as HTMLInputElement;
+    const select2 = getByLabelText("Exit country") as HTMLSelectElement;
+    expect(input2.value).toBe("https://w3");
+    expect(select2.value).toBe("DE");
+
+    const stored = await db.settings.get(1);
+    expect(stored?.workerList).toContain("https://w3");
+    expect(stored?.exitCountry).toBe("DE");
   });
 });

--- a/src/__tests__/TorChain.spec.ts
+++ b/src/__tests__/TorChain.spec.ts
@@ -1,68 +1,84 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/svelte";
 
 // Mock tauri event listener so store initialization doesn't fail
-vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn() }));
 
 // Provide a minimal mock for the uiStore used by TorChain
 const setExitCountry = vi.fn();
-vi.mock('$lib/stores/uiStore', () => {
-  const { writable } = require('svelte/store');
-  const store = writable({ settings: { exitCountry: null } });
+vi.mock("$lib/stores/uiStore", () => {
+  const { writable, get } = require("svelte/store");
+  const store = writable({
+    settings: { exitCountry: null },
+    cloudflareEnabled: false,
+  });
   return {
     uiStore: {
       subscribe: store.subscribe,
       actions: {
         setExitCountry: (country: string | null) => {
           setExitCountry(country);
-          store.set({ settings: { exitCountry: country } });
+          const current = get(store);
+          store.set({
+            settings: { exitCountry: country },
+            cloudflareEnabled: current.cloudflareEnabled,
+          });
+        },
+        setCloudflareEnabled: (val: boolean) => {
+          const current = get(store);
+          store.set({ ...current, cloudflareEnabled: val });
         },
       },
     },
   };
 });
 
-import TorChain from '../lib/components/TorChain.svelte';
+import TorChain from "../lib/components/TorChain.svelte";
 
 const nodeData = [
-  { nickname: 'entry', ip_address: '1.1.1.1', country: 'DE' },
-  { nickname: 'middle', ip_address: '2.2.2.2', country: 'FR' },
-  { nickname: 'exit', ip_address: '3.3.3.3', country: 'US' },
+  { nickname: "entry", ip_address: "1.1.1.1", country: "DE" },
+  { nickname: "middle", ip_address: "2.2.2.2", country: "FR" },
+  { nickname: "exit", ip_address: "3.3.3.3", country: "US" },
 ];
 
-describe('TorChain', () => {
-  it('renders node card data only when connected', () => {
+describe("TorChain", () => {
+  it("renders node card data only when connected", () => {
     const { queryByText: queryDisconnected, getByRole } = render(TorChain, {
       props: { isConnected: false, nodeData },
     });
-    expect(getByRole('region')).toHaveAttribute('aria-label', 'Tor chain configuration');
-    expect(queryDisconnected('1.1.1.1')).not.toBeInTheDocument();
+    expect(getByRole("region")).toHaveAttribute(
+      "aria-label",
+      "Tor chain configuration",
+    );
+    expect(queryDisconnected("1.1.1.1")).not.toBeInTheDocument();
 
     const { getByText } = render(TorChain, {
       props: { isConnected: true, nodeData },
     });
-    expect(getByText('1.1.1.1')).toBeInTheDocument();
-    expect(getByText('entry')).toBeInTheDocument();
+    expect(getByText("1.1.1.1")).toBeInTheDocument();
+    expect(getByText("entry")).toBeInTheDocument();
   });
 
-  it('calls setExitCountry when exit dropdown changes', async () => {
+  it("calls setExitCountry when exit dropdown changes", async () => {
     const { getByLabelText } = render(TorChain, {
       props: { isConnected: true, nodeData },
     });
 
-    const select = getByLabelText('Preferred exit country') as HTMLSelectElement;
-    await fireEvent.change(select, { target: { value: 'US' } });
+    const select = getByLabelText(
+      "Preferred exit country",
+    ) as HTMLSelectElement;
+    await fireEvent.change(select, { target: { value: "US" } });
 
-    expect(setExitCountry).toHaveBeenCalledWith('US');
+    expect(setExitCountry).toHaveBeenCalledWith("US");
   });
 
-  it('displays isolated circuits list', () => {
+  it("displays isolated circuits list", () => {
     const isolatedCircuits = [
       {
-        domain: 'example.com',
+        domain: "example.com",
         nodes: [
-          { nickname: 'n1', ip_address: '1.1.1.1', country: 'DE' },
-          { nickname: 'n2', ip_address: '2.2.2.2', country: 'FR' },
+          { nickname: "n1", ip_address: "1.1.1.1", country: "DE" },
+          { nickname: "n2", ip_address: "2.2.2.2", country: "FR" },
         ],
       },
     ];
@@ -71,7 +87,22 @@ describe('TorChain', () => {
       props: { isConnected: true, nodeData, isolatedCircuits },
     });
 
-    expect(getByText('Isolated Circuits')).toBeInTheDocument();
+    expect(getByText("Isolated Circuits")).toBeInTheDocument();
     expect(getByText(/example.com/)).toBeInTheDocument();
+  });
+
+  it("updates cloudflare node info when store value changes", async () => {
+    const cfNode = { nickname: "cf", ip_address: "4.4.4.4", country: "NL" };
+    const { uiStore } = await import("../lib/stores/uiStore");
+    const { queryByText } = render(TorChain, {
+      props: { isConnected: true, nodeData: [...nodeData, cfNode] },
+    });
+
+    expect(queryByText("4.4.4.4")).not.toBeInTheDocument();
+
+    uiStore.actions.setCloudflareEnabled(true);
+    await Promise.resolve();
+
+    expect(queryByText("4.4.4.4")).toBeInTheDocument();
   });
 });

--- a/src/lib/components/TorChain.svelte
+++ b/src/lib/components/TorChain.svelte
@@ -315,21 +315,33 @@
 		</div>
 		
 		<!-- Cloudflare Card -->
-		<div class="bg-black/50 rounded-xl p-4 flex flex-col min-h-[200px] {cloudflareEnabled ? '' : 'opacity-50'}">
+                <div class="bg-black/50 rounded-xl p-4 flex flex-col min-h-[200px] {cloudflareEnabled ? '' : 'opacity-50'}" tabindex="0" aria-label="Cloudflare node">
 			<div class="flex justify-center items-center h-12 mb-2">
 				<div class="text-3xl {cloudflareEnabled ? '' : 'opacity-50'}">☁️</div>
 			</div>
 			<div class="text-center flex-1 flex flex-col justify-center space-y-1">
 				<div class="text-sm {cloudflareEnabled ? 'text-white' : 'text-gray-300'} font-medium h-5 flex items-center justify-center">Cloudflare</div>
-				<div class="text-xs {cloudflareEnabled ? 'text-gray-200' : 'text-gray-400'} h-4 flex items-center justify-center">
-					-
-				</div>
-				<div class="text-lg h-6 flex items-center justify-center">
-					-
-				</div>
-				<div class="text-xs text-gray-200 h-4 flex items-center justify-center">
-					-
-				</div>
+                                <div class="text-xs {cloudflareEnabled ? 'text-gray-200' : 'text-gray-400'} h-4 flex items-center justify-center">
+                                        {#if isConnected && cloudflareEnabled && nodeData[3]}
+                                                {nodeData[3].ip_address}
+                                        {:else}
+                                                -
+                                        {/if}
+                                </div>
+                                <div class="text-lg h-6 flex items-center justify-center">
+                                        {#if isConnected && cloudflareEnabled && nodeData[3]}
+                                                {getCountryFlag(nodeData[3].country)}
+                                        {:else}
+                                                -
+                                        {/if}
+                                </div>
+                                <div class="text-xs text-gray-200 h-4 flex items-center justify-center">
+                                        {#if isConnected && cloudflareEnabled && nodeData[3]}
+                                                {nodeData[3].nickname}
+                                        {:else}
+                                                -
+                                        {/if}
+                                </div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary
- update Cloudflare card to show node data when enabled
- expand TorChain unit tests for Cloudflare toggle
- add regression test for SettingsModal reopen persistence

## Testing
- `npx vitest run` *(fails: 10 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686ab09327ec83338a0cdb2c486b719a