### PR TITLE
Implement token refresh on invalid sessions

### DIFF
--- a/src/__tests__/TorStore.spec.ts
+++ b/src/__tests__/TorStore.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 
 let statusCallback: (event: any) => void = () => {};
@@ -7,13 +7,41 @@ vi.mock('@tauri-apps/api/event', () => ({
     if (event === 'tor-status-update') statusCallback = cb;
   })
 }));
-vi.mock('@tauri-apps/api/tauri', () => ({ invoke: vi.fn() }));
+var invoke: any;
+vi.mock('@tauri-apps/api/tauri', () => {
+  invoke = vi.fn();
+  return { invoke };
+});
 
 import { torStore } from '../lib/stores/torStore';
+import { invoke as call } from '../lib/api';
+
+beforeEach(() => {
+  invoke.mockReset();
+  statusCallback = () => {};
+});
 
 describe('torStore', () => {
   it('sets status to ERROR on failed connection', () => {
     statusCallback({ payload: { status: 'ERROR', errorMessage: 'fail' } });
     expect(get(torStore).status).toBe('ERROR');
+  });
+
+  it('requests a new token and retries on InvalidToken', async () => {
+    let tokens = ['t1', 't2'];
+    invoke.mockImplementation(async (cmd: string, args: any) => {
+      if (cmd === 'request_token') return tokens.shift();
+      if (args.token === 't1') throw new Error('Invalid session token');
+      return 'ok';
+    });
+
+    const result = await call('list_circuits');
+    expect(result).toBe('ok');
+    expect(invoke.mock.calls).toEqual([
+      ['request_token'],
+      ['list_circuits', { token: 't1' }],
+      ['request_token'],
+      ['list_circuits', { token: 't2' }],
+    ]);
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,20 +3,28 @@ import { errorStore } from '$lib/components/AppErrorBoundary.svelte';
 
 let token: string | null = null;
 
-export async function ensureToken(): Promise<string> {
-  if (token) return token;
+export async function ensureToken(force = false): Promise<string> {
+  if (!force && token) return token;
   token = await tauriInvoke<string>('request_token');
   return token;
 }
 
-export async function invoke(cmd: string, args: Record<string, any> = {}) {
+export async function invoke(
+  cmd: string,
+  args: Record<string, any> = {},
+  retried = false
+) {
   const t = await ensureToken();
   try {
     return await tauriInvoke(cmd, { token: t, ...args });
   } catch (err: any) {
     if (err && err.toString().includes('Invalid session token')) {
-      token = null;
-      errorStore.set(new Error('Session expired. Please retry.'));
+      if (retried) {
+        errorStore.set(new Error('Session expired. Please retry.'));
+      } else {
+        await ensureToken(true);
+        return invoke(cmd, args, true);
+      }
     }
     throw err;
   }


### PR DESCRIPTION
## Summary
- refresh session token automatically and retry failed calls
- test retry logic with expired tokens

## Testing
- `npm test` *(fails: missing window metadata and failing component tests)*
- `cargo test --quiet` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ab093c2cc8333aa90e4279b6f729d