### PR TITLE
Add avg circuit metrics to backend and charts

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -481,6 +481,8 @@ impl<C: TorClientBehavior> AppState<C> {
                         "circuit_count": circ.count,
                         "latency_ms": latency,
                         "oldest_age": circ.oldest_age,
+                        "avg_create_ms": circ.avg_create_ms,
+                        "failed_attempts": circ.failed_attempts,
                         "cpu_percent": cpu,
                         "network_bytes": network
                     }),

--- a/src/__tests__/ResourceDashboard.spec.ts
+++ b/src/__tests__/ResourceDashboard.spec.ts
@@ -40,4 +40,24 @@ describe("ResourceDashboard", () => {
     expect(getAllByRole("alert").length).toBe(2);
     expect(container).toMatchSnapshot();
   });
+
+  it("renders chart paths for build metrics", async () => {
+    const { container } = render(ResourceDashboard);
+    await tick();
+    metricsCallback({
+      payload: {
+        memory_bytes: 1000,
+        circuit_count: 1,
+        latency_ms: 0,
+        oldest_age: 0,
+        avg_create_ms: 10,
+        failed_attempts: 2,
+        cpu_percent: 0,
+        network_bytes: 0,
+      },
+    });
+    await tick();
+    const svg = container.querySelector('svg[aria-label="Tor metrics chart"]');
+    expect(svg?.querySelectorAll("path").length).toBe(5);
+  });
 });

--- a/src/lib/components/MetricsChart.svelte
+++ b/src/lib/components/MetricsChart.svelte
@@ -21,6 +21,8 @@
   $: memoryPath = buildPath(metrics, "memoryMB");
   $: circuitPath = buildPath(metrics, "circuitCount");
   $: agePath = buildPath(metrics, "oldestAge");
+  $: avgPath = buildPath(metrics, "avgCreateMs");
+  $: failPath = buildPath(metrics, "failedAttempts");
 </script>
 
 <svg {width} {height} class="text-green-400" role="img" aria-label="Tor metrics chart">
@@ -48,6 +50,23 @@
       stroke="orange"
       stroke-width="1"
       stroke-dasharray="2,2"
+    />
+  {/if}
+  {#if avgPath}
+    <path
+      d={avgPath}
+      fill="none"
+      stroke="purple"
+      stroke-width="1"
+    />
+  {/if}
+  {#if failPath}
+    <path
+      d={failPath}
+      fill="none"
+      stroke="red"
+      stroke-width="1"
+      stroke-dasharray="4,2"
     />
   {/if}
 </svg>


### PR DESCRIPTION
## Summary
- emit `avg_create_ms` and `failed_attempts` with `metrics-update`
- visualize avg build time and failed attempts in `MetricsChart`
- extend ResourceDashboard tests for new metric paths

## Testing
- `bun x vitest run` *(fails: Cannot find package '@sveltejs/kit')*

------
https://chatgpt.com/codex/tasks/task_e_686af77874fc83338f8457cb9dcdb97b