### PR TITLE
Implement update interval setting

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -32,3 +32,5 @@ Nach dem Speichern der Einstellungen werden alle über den Worker geleiteten Ver
 ## Hardware Security Module verwenden
 
 Unter **Settings → HSM Configuration** kannst du den Pfad zur PKCS#11‑Bibliothek und den Slot angeben. Nach dem Speichern werden die Werte im Backend übernommen und für neue TLS‑Verbindungen genutzt.
+
+Unter **Settings → Update Interval** legst du fest, in welchem Abstand (in Sekunden) das Zertifikat automatisch aktualisiert wird.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -291,6 +291,13 @@ pub async fn set_hsm_config(
 }
 
 #[tauri::command]
+pub async fn set_update_interval(state: State<'_, AppState>, interval: u64) -> Result<()> {
+    check_api_rate()?;
+    state.set_update_interval(interval).await;
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn list_bridge_presets() -> Result<Vec<BridgePreset>> {
     crate::tor_manager::load_default_bridge_presets()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -165,6 +165,7 @@ pub fn run() {
             commands::clear_logs,
             commands::get_log_file_path,
             commands::set_log_limit,
+            commands::set_update_interval,
             commands::ping_host,
             commands::dns_lookup,
             commands::traceroute_host,

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -28,6 +28,7 @@
   let newWorker = "";
   let workerToken = "";
   let maxLogLines = 1000;
+  let updateInterval = 86400;
   let exitCountry: string | null = null;
   let hsmLib: string | null = null;
   let hsmSlot: number | null = null;
@@ -50,6 +51,7 @@
     newWorker = "";
     workerToken = $uiStore.settings.workerToken;
     maxLogLines = $uiStore.settings.maxLogLines;
+    updateInterval = $uiStore.settings.updateInterval;
     exitCountry = $uiStore.settings.exitCountry ?? null;
     hsmLib = $uiStore.settings.hsm_lib;
     hsmSlot = $uiStore.settings.hsm_slot;
@@ -112,6 +114,13 @@
     const limit = parseInt(String(maxLogLines));
     if (!isNaN(limit) && limit > 0) {
       uiStore.actions.setLogLimit(limit);
+    }
+  }
+
+  function saveUpdateInterval() {
+    const val = parseInt(String(updateInterval));
+    if (!isNaN(val) && val >= 0) {
+      uiStore.actions.saveUpdateInterval(val);
     }
   }
 
@@ -341,6 +350,26 @@
             class="text-sm py-2 px-4 mt-2 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
             on:click={saveLogLimit}
             aria-label="Save log limit"
+          >
+            Save
+          </button>
+        </div>
+
+        <div class="mb-8">
+          <h3 class="text-lg font-semibold mb-4 border-b border-white/10 pb-2">
+            Update Interval
+          </h3>
+          <input
+            type="number"
+            min="0"
+            class="w-full bg-black/50 rounded border border-white/20 p-2 text-sm"
+            bind:value={updateInterval}
+            aria-label="Update interval"
+          />
+          <button
+            class="text-sm py-2 px-4 mt-2 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
+            on:click={saveUpdateInterval}
+            aria-label="Save update interval"
           >
             Save
           </button>

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -129,6 +129,7 @@ export interface Settings {
   maxLogLines?: number;
   hsm_lib?: string | null;
   hsm_slot?: number | null;
+  updateInterval?: number;
 }
 
 export class AppDatabase extends Dexie {
@@ -156,6 +157,11 @@ export class AppDatabase extends Dexie {
     this.version(5).stores({
       settings:
         "++id, workerList, torrcConfig, workerToken, exitCountry, bridges, maxLogLines, bridgePreset, hsm_lib, hsm_slot",
+      meta: "&id",
+    });
+    this.version(6).stores({
+      settings:
+        "++id, workerList, torrcConfig, workerToken, exitCountry, bridges, maxLogLines, bridgePreset, hsm_lib, hsm_slot, updateInterval",
       meta: "&id",
     });
 


### PR DESCRIPTION
## Summary
- restart certificate scheduler from `AppState`
- expose command `set_update_interval`
- load and store `updateInterval` in the front-end database and store
- allow editing the update interval in the settings modal
- document how to configure the interval

## Testing
- `bun run test` *(fails: 10 failed, 5 passed)*
- `cargo check` *(fails: glib-2.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_686af77946708333b80ef3742888b24b