### PR TITLE
Add systemd install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ Im Ordner `cf worker` liegt ein kleines Beispiel für einen HTTPS-Proxy als Clou
 
 Eine ausführlichere Anleitung findet sich in
 [docs/Todo-fuer-User.md](docs/Todo-fuer-User.md).
-
+Um den systemd-Service schnell einzurichten, kann das Skript
+`scripts/install_service.sh` verwendet werden.
 
 ## Production Deployment
 

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -18,6 +18,17 @@ The service starts `/opt/torwell84/Torwell84` as the `torwell` user and group
 and restarts automatically on failure. Logs are available with
 `journalctl -u torwell84.service`.
 
+## Service Installation
+
+Instead of manually copying the unit file you can use the helper script:
+
+```bash
+./scripts/install_service.sh
+```
+
+It installs the service to `/etc/systemd/system/`, reloads systemd and enables
+`torwell84.service` immediately.
+
 ## Certificate Configuration
 
 Edit `src-tauri/certs/cert_config.json` to point to your production update server:

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SERVICE_FILE="$REPO_ROOT/src-tauri/torwell84.service"
+
+sudo cp "$SERVICE_FILE" /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now torwell84.service


### PR DESCRIPTION
## Summary
- add `install_service.sh` for systemd installation
- document helper script in ProductionDeployment
- mention script under "Deployment" in README

## Testing
- `bun install`
- `bun run test` *(fails: vitest tests 22 failing)*

------
https://chatgpt.com/codex/tasks/task_e_686b9c0854308333aa7a734818a069fc