### PR TITLE
Add systemd installation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,14 @@ Logs lassen sich anschließend mit `journalctl -u torwell84.service` abrufen.
 Weitere Hinweise zur Einrichtung finden sich in
 [docs/ProductionDeployment.md](docs/ProductionDeployment.md).
 
+Zur schnellen Installation kopiert das Skript `scripts/install_service.sh` die
+Unit-Datei nach `/etc/systemd/system/`, lädt systemd neu und startet den
+Dienst:
+
+```bash
+sudo ./scripts/install_service.sh
+```
+
 ## Installation
 
 ### Windows Installation

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -18,6 +18,17 @@ The service starts `/opt/torwell84/Torwell84` as the `torwell` user and group
 and restarts automatically on failure. Logs are available with
 `journalctl -u torwell84.service`.
 
+## Service Installation
+
+Instead of running the commands manually you can use the helper script:
+
+```bash
+sudo ./scripts/install_service.sh
+```
+
+The script copies `src-tauri/torwell84.service` into `/etc/systemd/system/`,
+reloads systemd and enables the service immediately.
+
 ## Certificate Configuration
 
 Edit `src-tauri/certs/cert_config.json` to point to your production update server:

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+# Copy service file to systemd directory
+sudo cp "$(dirname "$(dirname "$0")")/src-tauri/torwell84.service" /etc/systemd/system/
+
+# Reload systemd manager configuration
+sudo systemctl daemon-reload
+
+# Enable and start the service immediately
+sudo systemctl enable --now torwell84.service


### PR DESCRIPTION
## Summary
- add `install_service.sh` to automate systemd setup
- document new helper in production deployment guide
- mention script usage in README

## Testing
- `cargo test` *(fails: javascriptcoregtk-4.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686af77a54ac83339dfc4ae86b2e9073