### PR TITLE
Add configurable update interval

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -32,3 +32,7 @@ Nach dem Speichern der Einstellungen werden alle über den Worker geleiteten Ver
 ## Hardware Security Module verwenden
 
 Unter **Settings → HSM Configuration** kannst du den Pfad zur PKCS#11‑Bibliothek und den Slot angeben. Nach dem Speichern werden die Werte im Backend übernommen und für neue TLS‑Verbindungen genutzt.
+
+## Zertifikats-Updates
+
+Das Intervall, in dem Torwell84 nach neuen Zertifikaten sucht, stellst du im Bereich **Settings → Update Interval** ein. Der Wert wird in Sekunden angegeben.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -427,6 +427,13 @@ pub async fn set_log_limit(state: State<'_, AppState>, limit: usize) -> Result<(
 }
 
 #[tauri::command]
+pub async fn set_update_interval(state: State<'_, AppState>, seconds: u64) -> Result<()> {
+    check_api_rate()?;
+    state.set_update_interval(seconds).await;
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn ping_host(
     state: State<'_, AppState>,
     token: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -165,6 +165,7 @@ pub fn run() {
             commands::clear_logs,
             commands::get_log_file_path,
             commands::set_log_limit,
+            commands::set_update_interval,
             commands::ping_host,
             commands::dns_lookup,
             commands::traceroute_host,

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -28,6 +28,7 @@
   let newWorker = "";
   let workerToken = "";
   let maxLogLines = 1000;
+  let updateInterval = 86400;
   let exitCountry: string | null = null;
   let hsmLib: string | null = null;
   let hsmSlot: number | null = null;
@@ -50,6 +51,7 @@
     newWorker = "";
     workerToken = $uiStore.settings.workerToken;
     maxLogLines = $uiStore.settings.maxLogLines;
+    updateInterval = $uiStore.settings.updateInterval;
     exitCountry = $uiStore.settings.exitCountry ?? null;
     hsmLib = $uiStore.settings.hsm_lib;
     hsmSlot = $uiStore.settings.hsm_slot;
@@ -112,6 +114,13 @@
     const limit = parseInt(String(maxLogLines));
     if (!isNaN(limit) && limit > 0) {
       uiStore.actions.setLogLimit(limit);
+    }
+  }
+
+  function saveUpdateInterval() {
+    const seconds = parseInt(String(updateInterval));
+    if (!isNaN(seconds) && seconds > 0) {
+      uiStore.actions.saveUpdateInterval(seconds);
     }
   }
 
@@ -341,6 +350,26 @@
             class="text-sm py-2 px-4 mt-2 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
             on:click={saveLogLimit}
             aria-label="Save log limit"
+          >
+            Save
+          </button>
+        </div>
+
+        <div class="mb-8">
+          <h3 class="text-lg font-semibold mb-4 border-b border-white/10 pb-2">
+            Update Interval
+          </h3>
+          <input
+            type="number"
+            min="1"
+            class="w-full bg-black/50 rounded border border-white/20 p-2 text-sm"
+            bind:value={updateInterval}
+            aria-label="Update interval seconds"
+          />
+          <button
+            class="text-sm py-2 px-4 mt-2 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
+            on:click={saveUpdateInterval}
+            aria-label="Save update interval"
           >
             Save
           </button>

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -127,6 +127,7 @@ export interface Settings {
   bridges?: string[];
   bridgePreset?: string | null;
   maxLogLines?: number;
+  updateInterval?: number;
   hsm_lib?: string | null;
   hsm_slot?: number | null;
 }
@@ -156,6 +157,11 @@ export class AppDatabase extends Dexie {
     this.version(5).stores({
       settings:
         "++id, workerList, torrcConfig, workerToken, exitCountry, bridges, maxLogLines, bridgePreset, hsm_lib, hsm_slot",
+      meta: "&id",
+    });
+    this.version(6).stores({
+      settings:
+        "++id, workerList, torrcConfig, workerToken, exitCountry, bridges, maxLogLines, bridgePreset, hsm_lib, hsm_slot, updateInterval",
       meta: "&id",
     });
 


### PR DESCRIPTION
## Summary
- allow changing certificate update interval at runtime
- persist the value and add new UI control
- expose `set_update_interval` command
- document how to set the interval

## Testing
- `npm test` *(fails: vitest not found)*
- `cargo check` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9c07bd98833380f8e914b1904675