### PR TITLE
Add worker list import support

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -27,6 +27,8 @@ Dieses Dokument beschreibt, wie du den Beispiel‑Worker aus dem Ordner `cf work
 
 Trage die URL deines Workers in der Anwendung unter **Settings → Worker List** ein und hinterlege das geheime Token im Feld **Worker token**. Du kannst mehrere Adressen hinzufügen. Torwell84 probiert sie nacheinander aus und rotiert automatisch weiter, wenn ein Endpunkt nicht erreichbar ist. Alternativ kannst du Adressen in `src/lib/bridge_presets.json` hinterlegen, damit sie beim ersten Start bereits vorgeschlagen werden.
 
+Um viele Worker-Adressen komfortabel einzubinden, liest das Skript `scripts/import_workers.ts` eine Datei mit jeweils einer URL pro Zeile und übergibt sie per `set_worker_config` an den laufenden Dienst. Im Einstellungsdialog steht zudem der Button **Import Worker List** bereit, der die Liste aus einer Datei übernimmt.
+
 Nach dem Speichern der Einstellungen werden alle über den Worker geleiteten Verbindungen mit dem gesetzten Token authentifiziert. Mehrere Worker erhöhen Zuverlässigkeit und ermöglichen eine einfache horizontale Skalierung.
 
 ## Hardware Security Module verwenden

--- a/scripts/import_workers.ts
+++ b/scripts/import_workers.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env bun
+import { invoke } from '@tauri-apps/api/tauri';
+import { readFileSync } from 'fs';
+
+async function main() {
+  const file = process.argv[2];
+  const token = process.argv[3] ?? '';
+  if (!file) {
+    console.error('Usage: import_workers.ts <file> [token]');
+    process.exit(1);
+  }
+  const content = readFileSync(file, 'utf-8');
+  const workers = content
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  await invoke('set_worker_config', { workers, token });
+  console.log(`Imported ${workers.length} workers`);
+}
+
+main();

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -32,6 +32,7 @@
   let exitCountry: string | null = null;
   let hsmLib: string | null = null;
   let hsmSlot: number | null = null;
+  let filePicker: HTMLInputElement | null = null;
   // import TorrcEditorModal from './TorrcEditorModal.svelte';
 
   export let show: boolean;
@@ -108,6 +109,16 @@
 
   function removeWorker(index: number) {
     workerList = workerList.filter((_, i) => i !== index);
+  }
+
+  async function importFile(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+    const text = await input.files[0].text();
+    workerList = text
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
   }
 
   function saveLogLimit() {
@@ -315,6 +326,20 @@
               <Plus size={16} />
             </button>
           </div>
+          <input
+            type="file"
+            accept="text/*"
+            class="hidden"
+            on:change={importFile}
+            bind:this={filePicker}
+          />
+          <button
+            class="text-sm py-2 px-4 mb-2 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
+            on:click={() => filePicker && filePicker.click()}
+            aria-label="Import worker list"
+          >
+            Import Worker List
+          </button>
           <input
             type="text"
             class="w-full bg-black/50 rounded border border-white/20 p-2 text-sm mt-2"


### PR DESCRIPTION
## Summary
- implement `scripts/import_workers.ts` for bulk registration via `set_worker_config`
- add Import Worker List button to SettingsModal
- document the helper script in Todo-fuer-User guide

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*
- `bun run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bab25ba088333ab0ad4f2834cf32c