### PR TITLE
Reuse mobile frontend build

### DIFF
--- a/docs/Mobile.md
+++ b/docs/Mobile.md
@@ -25,6 +25,18 @@ The Svelte frontend is reused by pointing `webDir` to the compiled web assets.
    ./mobile/scripts/build_ios.sh       # generates the IPA (macOS required)
    ```
 
+### Reusing the frontend build
+
+The build scripts check if the `build/` directory already exists. If present,
+`bun run build` is skipped and the existing assets are reused. This shortens
+subsequent mobile builds, for example:
+
+```bash
+bun run build              # create web assets once
+./mobile/scripts/build_android.sh   # reuses build/
+./mobile/scripts/build_ios.sh
+```
+
 ## IPC Bridge
 
 When compiled with the `mobile` feature, the Rust backend automatically launches

--- a/mobile/scripts/build_android.sh
+++ b/mobile/scripts/build_android.sh
@@ -15,8 +15,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
 
 
-# Build the Svelte frontend
-bun run build
+# Build the Svelte frontend only if the build directory doesn't exist
+if [ -d "$ROOT_DIR/build" ]; then
+  echo "Reusing existing frontend build at $ROOT_DIR/build"
+else
+  (cd "$ROOT_DIR" && bun run build)
+fi
 
 # Compile the Rust backend with the `mobile` feature so the HTTP bridge is
 # available when the app runs.

--- a/mobile/scripts/build_ios.sh
+++ b/mobile/scripts/build_ios.sh
@@ -15,8 +15,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
 
 
-# Build the Svelte frontend
-bun run build
+# Build the Svelte frontend only if the build directory doesn't exist
+if [ -d "$ROOT_DIR/build" ]; then
+  echo "Reusing existing frontend build at $ROOT_DIR/build"
+else
+  (cd "$ROOT_DIR" && bun run build)
+fi
 
 # Compile the Rust backend with the `mobile` feature so the HTTP bridge is
 # available when the app runs.


### PR DESCRIPTION
## Summary
- skip web build if `build/` already exists
- document how to reuse the frontend build for faster mobile builds

## Testing
- `bun run check` *(fails: `svelte-kit` not found)*
- `cargo test` *(fails: `glib-2.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bab25ea7c83338534ed7a0c3a71c3