### PR TITLE
Enable worker list export

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -28,6 +28,7 @@ Dieses Dokument beschreibt, wie du den Beispiel‑Worker aus dem Ordner `cf work
 Trage die URL deines Workers in der Anwendung unter **Settings → Worker List** ein und hinterlege das geheime Token im Feld **Worker token**. Du kannst mehrere Adressen hinzufügen. Torwell84 probiert sie nacheinander aus und rotiert automatisch weiter, wenn ein Endpunkt nicht erreichbar ist. Alternativ kannst du Adressen in `src/lib/bridge_presets.json` hinterlegen, damit sie beim ersten Start bereits vorgeschlagen werden.
 
 Um viele Worker-Adressen komfortabel einzubinden, liest das Skript `scripts/import_workers.ts` eine Datei mit jeweils einer URL pro Zeile und übergibt sie per `set_worker_config` an den laufenden Dienst. Im Einstellungsdialog steht zudem der Button **Import Worker List** bereit, der die Liste aus einer Datei übernimmt.
+Ab Version 2.3 kannst du die aktuelle Liste auch über **Export Worker List** als Textdatei herunterladen und einfach weitergeben.
 
 Nach dem Speichern der Einstellungen werden alle über den Worker geleiteten Verbindungen mit dem gesetzten Token authentifiziert. Mehrere Worker erhöhen Zuverlässigkeit und ermöglichen eine einfache horizontale Skalierung.
 

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -121,6 +121,18 @@
       .filter((l) => l.length > 0);
   }
 
+  function exportFile() {
+    const blob = new Blob([workerList.join('\n')], {
+      type: 'text/plain',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'workers.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
   function saveLogLimit() {
     const limit = parseInt(String(maxLogLines));
     if (!isNaN(limit) && limit > 0) {
@@ -339,6 +351,13 @@
             aria-label="Import worker list"
           >
             Import Worker List
+          </button>
+          <button
+            class="text-sm py-2 px-4 mb-2 ml-2 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
+            on:click={exportFile}
+            aria-label="Export worker list"
+          >
+            Export Worker List
           </button>
           <input
             type="text"


### PR DESCRIPTION
## Summary
- support exporting workers from settings UI
- document export workflow in user guide

## Testing
- `bun test` *(fails: Cannot find module '@testing-library/svelte')*
- `cargo test` *(fails: glib-2.0.pc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb6f746a88333a99e4bad4460edd6