### PR TITLE
Improve service install and release scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/opt/torwell84/Torwell84
+ExecStart=/opt/torwell84/torwell84
 Restart=always
 User=torwell
 Group=torwell

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,3 +34,8 @@ tasks:
     desc: "Build the iOS app using Capacitor"
     cmds:
       - ./mobile/scripts/build_ios.sh
+
+  release:
+    desc: "Build MSI/DEB/DMG packages for the current platform"
+    cmds:
+      - ./scripts/build_release.sh

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -14,7 +14,7 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now torwell84.service
 ```
 
-The service starts `/opt/torwell84/Torwell84` as the `torwell` user and group
+The service starts `/opt/torwell84/torwell84` as the `torwell` user and group
 and restarts automatically on failure. Logs are available with
 `journalctl -u torwell84.service`.
 
@@ -51,3 +51,20 @@ If the value is greater than zero a background task periodically calls
 `update_certificates_from` to refresh the pinned certificate. You can override
 the interval at runtime using the `TORWELL_UPDATE_INTERVAL` environment
 variable.
+
+## Building Release Packages
+
+Run the release task on the target platform to create the installer packages.
+
+```bash
+task release   # invokes scripts/build_release.sh
+```
+
+Depending on the operating system this produces:
+
+- Windows: an `.msi` installer in `src-tauri/target/release/bundle/msi`
+- Linux: `.deb` and `.AppImage` files under `src-tauri/target/release/bundle`
+- macOS: a `.dmg` image in `src-tauri/target/release/bundle/dmg`
+
+Copy the resulting package to the production machine and install it before
+enabling the systemd service.

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+check_dep() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' is required but not installed." >&2
+    exit 1
+  fi
+}
+
+for cmd in bun cargo; do
+  check_dep "$cmd"
+done
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+(cd "$ROOT_DIR" && bun install)
+(cd "$ROOT_DIR" && bun run tauri build)
+
+echo "Bundles written to $ROOT_DIR/src-tauri/target/release/bundle"

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 set -e
 
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Create service user and group if they do not exist
+if ! id torwell >/dev/null 2>&1; then
+  sudo useradd --system --user-group --home /opt/torwell84 torwell
+fi
+
+# Ensure application directory exists
+sudo mkdir -p /opt/torwell84
+
 # Copy service file to systemd directory
-sudo cp "$(dirname "$(dirname "$0")")/src-tauri/torwell84.service" /etc/systemd/system/
+sudo cp "$ROOT_DIR/src-tauri/torwell84.service" /etc/systemd/system/
 
 # Reload systemd manager configuration
 sudo systemctl daemon-reload

--- a/src-tauri/torwell84.service
+++ b/src-tauri/torwell84.service
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/opt/torwell84/Torwell84
+ExecStart=/opt/torwell84/torwell84
 Restart=always
 User=torwell
 Group=torwell


### PR DESCRIPTION
## Summary
- fix systemd unit to launch `torwell84`
- create service user and directory in install script
- add `build_release.sh` helper and Taskfile entry
- document package build steps in deployment guide
- update README service snippet

## Testing
- `bun run check` *(fails: svelte-check errors)*
- `bun run lint:a11y` *(fails: svelte-check errors)*
- `cargo check` *(fails: missing system libraries)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686bb6fa071883338b8456477360ae17