### PR TITLE
Add mobile release task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,6 +35,15 @@ tasks:
     cmds:
       - ./mobile/scripts/build_ios.sh
 
+  mobile:release:
+    desc: "Build Android and iOS apps and collect artifacts"
+    cmds:
+      - task mobile:android
+      - task mobile:ios
+      - mkdir -p mobile/dist
+      - cp mobile/android/*.apk mobile/dist/ 2>/dev/null || true
+      - cp mobile/ios/*.ipa mobile/dist/ 2>/dev/null || true
+
   release:
     desc: "Build MSI/DEB/DMG packages for the current platform"
     cmds:

--- a/docs/Mobile.md
+++ b/docs/Mobile.md
@@ -11,6 +11,7 @@ The Svelte frontend is reused by pointing `webDir` to the compiled web assets.
    ```bash
    task mobile:android  # Build Android APK
    task mobile:ios      # Build iOS project
+   task mobile:release  # Build both and gather artifacts
    ```
 
    Each task performs the following:
@@ -18,7 +19,9 @@ The Svelte frontend is reused by pointing `webDir` to the compiled web assets.
    - `cargo build --release --manifest-path src-tauri/Cargo.toml --features mobile` compiles the Rust backend so the HTTP bridge is included.
    - The Capacitor CLI then copies the assets and builds the native project.
 
-3. To create the final application packages manually run:
+3. To create the final application packages run `task mobile:release`. The command
+   copies the resulting archives to `mobile/dist/`. You can still execute the
+   scripts directly if desired:
 
    ```bash
    ./mobile/scripts/build_android.sh   # generates the APK
@@ -70,8 +73,21 @@ git clone https://github.com/Christopher-Schulze/Torwell.git
 cd Torwell
 task setup        # installiert alle Abhängigkeiten
 task mobile:android  # oder `task mobile:ios`
+task mobile:release  # erstellt beide Pakete
 ```
 
-Nach erfolgreichem Lauf findest du das Android‑APK im Ordner
-`mobile/android/app/build/outputs/apk/`. Für iOS wird ein Xcode-Projekt unter
-`mobile/ios` erzeugt, das sich anschließend in Xcode bauen lässt.
+Die fertigen Dateien landen im Verzeichnis `mobile/dist`. Nach erfolgreichem
+Lauf findest du das Android‑APK im Ordner `mobile/android/app/build/outputs/apk/`.
+Für iOS wird ein Xcode-Projekt unter `mobile/ios` erzeugt.
+
+## Testing the final builds
+
+- **Android:** Starte einen Emulator in Android Studio und installiere das APK:
+
+  ```bash
+  adb install mobile/dist/*.apk
+  ```
+
+- **iOS:** Öffne `mobile/ios/App.xcworkspace` in Xcode und wähle einen
+  Simulator aus. Du kannst das erzeugte `.ipa` aus `mobile/dist` auch über das
+  Geräte-Fenster von Xcode auf ein verbundenes Gerät ziehen.

--- a/mobile/scripts/build_android.sh
+++ b/mobile/scripts/build_android.sh
@@ -31,3 +31,14 @@ cd "$SCRIPT_DIR/.."
 bun install
 npx cap copy android
 npx cap build android
+
+# Copy the generated APK to a predictable location
+APK_PATH=$(find android/app/build/outputs/apk -name "*.apk" | head -n 1 || true)
+if [ -n "$APK_PATH" ]; then
+  DEST_DIR="$SCRIPT_DIR/../android"
+  mkdir -p "$DEST_DIR"
+  cp "$APK_PATH" "$DEST_DIR/"
+  echo "APK copied to $DEST_DIR/$(basename "$APK_PATH")"
+else
+  echo "No APK produced" >&2
+fi

--- a/mobile/scripts/build_ios.sh
+++ b/mobile/scripts/build_ios.sh
@@ -31,3 +31,14 @@ cd "$SCRIPT_DIR/.."
 bun install
 npx cap copy ios
 npx cap build ios
+
+# Copy the generated IPA to a predictable location
+IPA_PATH=$(find ios -name "*.ipa" | head -n 1 || true)
+if [ -n "$IPA_PATH" ]; then
+  DEST_DIR="$SCRIPT_DIR/../ios"
+  mkdir -p "$DEST_DIR"
+  cp "$IPA_PATH" "$DEST_DIR/"
+  echo "IPA copied to $DEST_DIR/$(basename "$IPA_PATH")"
+else
+  echo "No IPA produced" >&2
+fi


### PR DESCRIPTION
## Summary
- enhance build scripts to copy resulting APK/IPA files
- add `task mobile:release` to build both platforms
- document how to run the new task and test builds via emulators

## Testing
- `bun run check` *(fails: svelte-kit not found)*
- `bun run lint:a11y` *(fails: svelte-kit not found)*
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` *(fails: clippy component missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bc19db4088333af4b8ce088f8849f