### PR TITLE
Add worker setup help modal and import/export

### DIFF
--- a/scripts/import_workers.ts
+++ b/scripts/import_workers.ts
@@ -2,6 +2,15 @@
 import { invoke } from '@tauri-apps/api/tauri';
 import { readFileSync } from 'fs';
 
+export async function importWorkers(content: string, token: string = '') {
+  const workers = content
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  await invoke('set_worker_config', { workers, token });
+  return workers.length;
+}
+
 async function main() {
   const file = process.argv[2];
   const token = process.argv[3] ?? '';
@@ -10,12 +19,8 @@ async function main() {
     process.exit(1);
   }
   const content = readFileSync(file, 'utf-8');
-  const workers = content
-    .split(/\r?\n/)
-    .map((l) => l.trim())
-    .filter((l) => l.length > 0);
-  await invoke('set_worker_config', { workers, token });
-  console.log(`Imported ${workers.length} workers`);
+  const count = await importWorkers(content, token);
+  console.log(`Imported ${count} workers`);
 }
 
 main();

--- a/src/lib/components/WorkerSetupModal.svelte
+++ b/src/lib/components/WorkerSetupModal.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { createEventDispatcher, tick } from 'svelte';
+  import { X } from 'lucide-svelte';
+
+  export let show = false;
+
+  const dispatch = createEventDispatcher();
+  const docURL = new URL('../../docs/Todo-fuer-User.md', import.meta.url).href;
+
+  let content = '';
+  let closeButton: HTMLButtonElement | null = null;
+  let modalEl: HTMLElement | null = null;
+  let previouslyFocused: HTMLElement | null = null;
+
+  $: if (show) {
+    previouslyFocused = document.activeElement as HTMLElement;
+    fetch(docURL)
+      .then((r) => r.text())
+      .then((t) => (content = t));
+    tick().then(() => closeButton && closeButton.focus());
+  } else if (previouslyFocused) {
+    tick().then(() => previouslyFocused && previouslyFocused.focus());
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      dispatch('close');
+    }
+  }
+
+  function trapFocus(event: KeyboardEvent) {
+    if (event.key !== 'Tab' || !modalEl) return;
+    const focusable = Array.from(
+      modalEl.querySelectorAll<HTMLElement>('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+</script>
+
+<svelte:window on:keydown={handleKeyDown} />
+
+{#if show}
+  <div
+    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+    on:click={() => dispatch('close')}
+    tabindex="-1"
+  >
+    <section
+      class="glass-lg rounded-2xl w-[90%] max-w-2xl p-6 flex flex-col"
+      on:click|stopPropagation
+      on:keydown={trapFocus}
+      bind:this={modalEl}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="worker-setup-title"
+      tabindex="0"
+    >
+      <div class="flex justify-between items-center mb-4 shrink-0">
+        <h2 id="worker-setup-title" class="text-2xl font-semibold">Worker Setup</h2>
+        <button
+          class="text-gray-100 hover:text-white transition-colors"
+          on:click={() => dispatch('close')}
+          aria-label="Close worker setup"
+          bind:this={closeButton}
+        >
+          <X size={24} />
+        </button>
+      </div>
+      <pre class="overflow-y-auto whitespace-pre-wrap text-sm flex-grow">{content}</pre>
+    </section>
+  </div>
+{/if}

--- a/src/lib/stores/uiStore.ts
+++ b/src/lib/stores/uiStore.ts
@@ -310,6 +310,16 @@ function createUIStore() {
       await actions.saveWorkerConfig(current.settings.workerList, token);
     },
 
+    importWorkerList: async (workers: string[]) => {
+      const current = get({ subscribe });
+      await actions.saveWorkerConfig(workers, current.settings.workerToken);
+    },
+
+    exportWorkerList: () => {
+      const current = get({ subscribe });
+      return [...current.settings.workerList];
+    },
+
     setLogLimit: async (limit: number) => {
       try {
         await invoke("set_log_limit", { limit });


### PR DESCRIPTION
## Summary
- add Worker Setup modal to show instructions from docs
- integrate worker setup help button into settings
- import/export worker list via uiStore actions
- expose importWorkers from `scripts/import_workers.ts`

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc19cdca48333b7cefdaa8ee99393