### PR TITLE
Improve connection diagnostics

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -124,10 +124,13 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
                             .await;
                     });
                     let (step, source) = match err {
-                        Error::ConnectionFailed { step, source }
-                        | Error::Identity { step, source }
-                        | Error::NetworkFailure { step, source } => (step, source),
-                        _ => ("", ""),
+                        Error::ConnectionFailed { step, source } => {
+                            (step.to_string(), source.clone())
+                        }
+                        Error::Identity { step, source }
+                        | Error::NetworkFailure { step, source }
+                        | Error::ConfigError { step, source } => (step.clone(), source.clone()),
+                        _ => (String::new(), String::new()),
                     };
                     let _ = app_handle.emit_all(
                         "tor-status-update",
@@ -170,10 +173,11 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
             }
             Err(e) => {
                 let (step, source) = match &e {
-                    Error::ConnectionFailed { step, source }
-                    | Error::Identity { step, source }
-                    | Error::NetworkFailure { step, source } => (step.as_str(), source.as_str()),
-                    _ => ("", ""),
+                    Error::ConnectionFailed { step, source } => (step.to_string(), source.clone()),
+                    Error::Identity { step, source }
+                    | Error::NetworkFailure { step, source }
+                    | Error::ConfigError { step, source } => (step.clone(), source.clone()),
+                    _ => (String::new(), String::new()),
                 };
                 if let Err(e_emit) = app_handle.emit_all(
                     "tor-status-update",

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,5 +1,26 @@
 use serde::Serialize;
+use std::fmt;
 use thiserror::Error;
+
+#[derive(Debug, Serialize, Clone)]
+pub enum ConnectionStep {
+    BuildConfig,
+    Bootstrap,
+    Timeout,
+    RetriesExceeded,
+}
+
+impl fmt::Display for ConnectionStep {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            ConnectionStep::BuildConfig => "build_config",
+            ConnectionStep::Bootstrap => "bootstrap",
+            ConnectionStep::Timeout => "timeout",
+            ConnectionStep::RetriesExceeded => "retries_exceeded",
+        };
+        write!(f, "{}", s)
+    }
+}
 
 #[derive(Debug, Serialize, Error)]
 pub enum Error {
@@ -37,7 +58,10 @@ pub enum Error {
     Network(String),
 
     #[error("connection failed during {step}: {source}")]
-    ConnectionFailed { step: String, source: String },
+    ConnectionFailed {
+        step: ConnectionStep,
+        source: String,
+    },
 
     #[error("identity change failed during {step}: {source}")]
     Identity { step: String, source: String },


### PR DESCRIPTION
## Summary
- add `ConnectionStep` enum and use in `ConnectionFailed`
- log step using enum in `log_and_convert_error`
- propagate step info to UI

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bc19aeb988333a7467aaef7228e3b