### PR TITLE
Show avg circuit build time and failures

### DIFF
--- a/src/lib/components/MetricsChart.svelte
+++ b/src/lib/components/MetricsChart.svelte
@@ -79,3 +79,25 @@
     />
   {/if}
 </svg>
+<svg {width} {height} class="text-purple-300" role="img" aria-label="Average build time chart">
+  {#if avgPath}
+    <path
+      d={avgPath}
+      fill="currentColor"
+      fill-opacity="0.3"
+      stroke="currentColor"
+      stroke-width="1"
+    />
+  {/if}
+</svg>
+<svg {width} {height} class="text-red-400" role="img" aria-label="Failed attempts chart">
+  {#if failPath}
+    <path
+      d={failPath}
+      fill="currentColor"
+      fill-opacity="0.3"
+      stroke="currentColor"
+      stroke-width="1"
+    />
+  {/if}
+</svg>

--- a/src/lib/components/ResourceDashboard.svelte
+++ b/src/lib/components/ResourceDashboard.svelte
@@ -29,6 +29,8 @@
 
   $: cpuPath = buildPath(metrics, 'cpuPercent');
   $: networkPath = buildPath(metrics, 'networkBytes');
+  $: avgPath = buildPath(metrics, 'avgCreateMs');
+  $: failPath = buildPath(metrics, 'failedAttempts');
 
   $: latest =
     metrics[metrics.length - 1] ?? {
@@ -100,6 +102,22 @@
       <svg {width} {height} class="text-purple-400" aria-label="Network usage chart" role="img">
         {#if networkPath}
           <path d={networkPath} fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1" />
+        {/if}
+      </svg>
+    </div>
+    <div class="flex-1">
+      <p class="text-sm text-white">Avg build: {latest.avgCreateMs} ms</p>
+      <svg {width} {height} class="text-purple-300" aria-label="Average build time chart" role="img">
+        {#if avgPath}
+          <path d={avgPath} fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1" />
+        {/if}
+      </svg>
+    </div>
+    <div class="flex-1">
+      <p class="text-sm text-white">Failures: {latest.failedAttempts}</p>
+      <svg {width} {height} class="text-red-400" aria-label="Failed attempts chart" role="img">
+        {#if failPath}
+          <path d={failPath} fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1" />
         {/if}
       </svg>
     </div>


### PR DESCRIPTION
## Summary
- expose new metrics in ResourceDashboard
- display additional charts in ResourceDashboard and MetricsChart

## Testing
- `bun run check` *(fails: svelte-kit not found)*
- `bun run lint:a11y` *(fails: svelte-kit not found)*
- `cargo check` *(fails: glib-2.0 development files missing)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686bc73113388333b8f8b0006d4e87d9