### PR TITLE
Add configurable GeoIP path

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -106,7 +106,8 @@ pub async fn connect(app_handle: tauri::AppHandle, state: State<'_, AppState>) -
 
         // Perform the actual connection
         let _ = state_clone.reset_retry_counter().await;
-        match tor_manager
+        let mgr = tor_manager.read().await.clone();
+        match mgr
             .connect_with_backoff(
                 5,
                 Duration::from_secs(60), // place to capture circuit build duration metrics
@@ -211,7 +212,10 @@ pub async fn disconnect(app_handle: tauri::AppHandle, state: State<'_, AppState>
         log::error!("Failed to emit status update: {}", e);
     }
 
-    state.tor_manager.disconnect().await?;
+    {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.disconnect().await?;
+    }
 
     if let Err(e) = app_handle.emit_all(
         "tor-status-update",
@@ -229,7 +233,10 @@ pub async fn disconnect(app_handle: tauri::AppHandle, state: State<'_, AppState>
 pub async fn get_status(state: State<'_, AppState>) -> Result<String> {
     track_call("get_status").await;
     check_api_rate()?;
-    if state.tor_manager.is_connected().await {
+    if {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.is_connected().await
+    } {
         Ok("CONNECTED".to_string())
     } else {
         Ok("DISCONNECTED".to_string())
@@ -240,7 +247,10 @@ pub async fn get_status(state: State<'_, AppState>) -> Result<String> {
 pub async fn get_active_circuit(state: State<'_, AppState>) -> Result<Vec<RelayInfo>> {
     track_call("get_active_circuit").await;
     check_api_rate()?;
-    state.tor_manager.get_active_circuit().await
+    {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.get_active_circuit().await
+    }
 }
 
 #[tauri::command]
@@ -250,21 +260,30 @@ pub async fn get_isolated_circuit(
 ) -> Result<Vec<RelayInfo>> {
     track_call("get_isolated_circuit").await;
     check_api_rate()?;
-    state.tor_manager.get_isolated_circuit(domain).await
+    {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.get_isolated_circuit(domain).await
+    }
 }
 
 #[tauri::command]
 pub async fn set_exit_country(state: State<'_, AppState>, country: Option<String>) -> Result<()> {
     track_call("set_exit_country").await;
     check_api_rate()?;
-    state.tor_manager.set_exit_country(country).await
+    {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.set_exit_country(country).await
+    }
 }
 
 #[tauri::command]
 pub async fn set_bridges(state: State<'_, AppState>, bridges: Vec<String>) -> Result<()> {
     track_call("set_bridges").await;
     check_api_rate()?;
-    state.tor_manager.set_bridges(bridges).await
+    {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.set_bridges(bridges).await
+    }
 }
 
 #[tauri::command]
@@ -301,6 +320,13 @@ pub async fn set_update_interval(state: State<'_, AppState>, interval: u64) -> R
 }
 
 #[tauri::command]
+pub async fn set_geoip_path(state: State<'_, AppState>, path: Option<String>) -> Result<()> {
+    check_api_rate()?;
+    state.set_geoip_path(path).await;
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn list_bridge_presets() -> Result<Vec<BridgePreset>> {
     crate::tor_manager::load_default_bridge_presets()
 }
@@ -309,7 +335,10 @@ pub async fn list_bridge_presets() -> Result<Vec<BridgePreset>> {
 pub async fn get_traffic_stats(state: State<'_, AppState>) -> Result<TrafficStats> {
     track_call("get_traffic_stats").await;
     check_api_rate()?;
-    let stats = state.tor_manager.traffic_stats().await?;
+    let stats = {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.traffic_stats().await?
+    };
     Ok(TrafficStats {
         bytes_sent: stats.bytes_sent,
         bytes_received: stats.bytes_received,
@@ -320,7 +349,10 @@ pub async fn get_traffic_stats(state: State<'_, AppState>) -> Result<TrafficStat
 pub async fn get_metrics(state: State<'_, AppState>) -> Result<Metrics> {
     track_call("get_metrics").await;
     check_api_rate()?;
-    let circ = state.tor_manager.circuit_metrics().await?; // capture more metrics like build time when available
+    let circ = {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.circuit_metrics().await?
+    }; // capture more metrics like build time when available
     let mut sys = sysinfo::System::new();
     let pid = sysinfo::get_current_pid().map_err(|e| Error::Io(e.to_string()))?;
     sys.refresh_process(pid);
@@ -372,7 +404,10 @@ pub async fn get_metrics(state: State<'_, AppState>) -> Result<Metrics> {
 pub async fn new_identity(app_handle: tauri::AppHandle, state: State<'_, AppState>) -> Result<()> {
     track_call("new_identity").await;
     check_api_rate()?;
-    state.tor_manager.new_identity().await?; // potential metric: measure time to build new circuit
+    {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.new_identity().await?;
+    } // potential metric: measure time to build new circuit
                                              // Emit event to update frontend
     app_handle.emit_all(
         "tor-status-update",
@@ -385,14 +420,20 @@ pub async fn new_identity(app_handle: tauri::AppHandle, state: State<'_, AppStat
 pub async fn list_circuits(state: State<'_, AppState>) -> Result<Vec<u64>> {
     track_call("list_circuits").await;
     check_api_rate()?;
-    state.tor_manager.list_circuit_ids().await
+    {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.list_circuit_ids().await
+    }
 }
 
 #[tauri::command]
 pub async fn close_circuit(state: State<'_, AppState>, id: u64) -> Result<()> {
     track_call("close_circuit").await;
     check_api_rate()?;
-    state.tor_manager.close_circuit(id).await
+    {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.close_circuit(id).await
+    }
 }
 #[tauri::command]
 pub async fn get_logs(state: State<'_, AppState>, token: String) -> Result<Vec<LogEntry>> {
@@ -560,7 +601,10 @@ pub async fn reconnect(app_handle: tauri::AppHandle, state: State<'_, AppState>)
     check_api_rate()?;
 
     // Attempt graceful disconnect; ignore errors if already disconnected
-    let _ = state.tor_manager.disconnect().await;
+    {
+        let mgr = state.tor_manager.read().await.clone();
+        let _ = mgr.disconnect().await;
+    }
 
     // Reuse existing connect logic
     connect(app_handle, state).await

--- a/src-tauri/src/http_bridge.rs
+++ b/src-tauri/src/http_bridge.rs
@@ -3,7 +3,10 @@ use std::{net::SocketAddr, sync::Arc};
 use crate::state::AppState;
 
 async fn status(Extension(state): Extension<Arc<AppState>>) -> Json<&'static str> {
-    let s = if state.tor_manager.is_connected().await {
+    let s = if {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.is_connected().await
+    } {
         "CONNECTED"
     } else {
         "DISCONNECTED"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,7 +30,10 @@ pub fn run() {
     let dashboard = CustomMenuItem::new("show_dashboard", "Show Dashboard");
     let reconnect = CustomMenuItem::new("reconnect", "Reconnect");
     let settings = CustomMenuItem::new("settings", "Settings");
-    let initial_connected = tauri::async_runtime::block_on(app_state.tor_manager.is_connected());
+    let initial_connected = tauri::async_runtime::block_on(async {
+        let mgr = app_state.tor_manager.read().await.clone();
+        mgr.is_connected().await
+    });
     let status = if initial_connected {
         "Connected"
     } else {
@@ -171,6 +174,7 @@ pub fn run() {
             commands::get_log_file_path,
             commands::set_log_limit,
             commands::set_update_interval,
+            commands::set_geoip_path,
             commands::ping_host,
             commands::dns_lookup,
             commands::traceroute_host,

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -34,6 +34,7 @@
   let exitCountry: string | null = null;
   let hsmLib: string | null = null;
   let hsmSlot: number | null = null;
+  let geoipPath: string | null = null;
   let filePicker: HTMLInputElement | null = null;
 
   export let show: boolean;
@@ -57,6 +58,7 @@
     exitCountry = $uiStore.settings.exitCountry ?? null;
     hsmLib = $uiStore.settings.hsm_lib;
     hsmSlot = $uiStore.settings.hsm_slot;
+    geoipPath = $uiStore.settings.geoipPath;
     uiStore.actions.setExitCountry(exitCountry);
     if (availableBridges.length === 0) loadPresets();
     tick().then(() => closeButton && closeButton.focus());
@@ -147,6 +149,10 @@
     if (!isNaN(val) && val >= 0) {
       uiStore.actions.saveUpdateInterval(val);
     }
+  }
+
+  function saveGeoipPath() {
+    uiStore.actions.saveGeoipPath(geoipPath);
   }
 
   function saveExitCountry() {
@@ -414,6 +420,26 @@
             class="text-sm py-2 px-4 mt-2 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
             on:click={saveUpdateInterval}
             aria-label="Save update interval"
+          >
+            Save
+          </button>
+        </div>
+
+        <div class="mb-8">
+          <h3 class="text-lg font-semibold mb-4 border-b border-white/10 pb-2">
+            GeoIP Directory
+          </h3>
+          <input
+            type="text"
+            class="w-full bg-black/50 rounded border border-white/20 p-2 text-sm"
+            bind:value={geoipPath}
+            placeholder="/path/to/geoip_dir"
+            aria-label="GeoIP directory"
+          />
+          <button
+            class="text-sm py-2 px-4 mt-2 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
+            on:click={saveGeoipPath}
+            aria-label="Save GeoIP directory"
           >
             Save
           </button>

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -130,6 +130,7 @@ export interface Settings {
   hsm_lib?: string | null;
   hsm_slot?: number | null;
   updateInterval?: number;
+  geoipPath?: string | null;
 }
 
 export class AppDatabase extends Dexie {
@@ -162,6 +163,11 @@ export class AppDatabase extends Dexie {
     this.version(6).stores({
       settings:
         "++id, workerList, torrcConfig, workerToken, exitCountry, bridges, maxLogLines, bridgePreset, hsm_lib, hsm_slot, updateInterval",
+      meta: "&id",
+    });
+    this.version(7).stores({
+      settings:
+        "++id, workerList, torrcConfig, workerToken, exitCountry, bridges, maxLogLines, bridgePreset, hsm_lib, hsm_slot, updateInterval, geoipPath",
       meta: "&id",
     });
 

--- a/src/lib/stores/uiStore.ts
+++ b/src/lib/stores/uiStore.ts
@@ -14,6 +14,7 @@ type AppSettings = {
   hsm_lib: string | null;
   hsm_slot: number | null;
   updateInterval: number;
+  geoipPath: string | null;
 };
 
 type UIState = {
@@ -40,6 +41,7 @@ function createUIStore() {
       hsm_lib: null,
       hsm_slot: null,
       updateInterval: 86400,
+      geoipPath: null,
     },
     error: null,
   });
@@ -84,6 +86,7 @@ function createUIStore() {
               hsm_lib: storedSettings.hsm_lib ?? null,
               hsm_slot: storedSettings.hsm_slot ?? null,
               updateInterval: storedSettings.updateInterval ?? 86400,
+              geoipPath: storedSettings.geoipPath ?? null,
             },
           }));
 
@@ -108,6 +111,7 @@ function createUIStore() {
           await invoke("set_update_interval", {
             interval: storedSettings.updateInterval ?? 86400,
           });
+          await invoke("set_geoip_path", { path: storedSettings.geoipPath ?? null });
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : "Unknown error";
@@ -354,6 +358,25 @@ function createUIStore() {
         update((state) => ({
           ...state,
           error: `Failed to set update interval: ${message}`,
+        }));
+      }
+    },
+
+    saveGeoipPath: async (path: string | null) => {
+      try {
+        await invoke("set_geoip_path", { path });
+        const current = get({ subscribe });
+        const newSettings: AppSettings = {
+          ...current.settings,
+          geoipPath: path,
+        };
+        await db.settings.put({ id: 1, ...newSettings });
+        update((state) => ({ ...state, settings: newSettings, error: null }));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        update((state) => ({
+          ...state,
+          error: `Failed to set geoip path: ${message}`,
         }));
       }
     },


### PR DESCRIPTION
## Summary
- allow user to set GeoIP directory in settings
- send chosen path to backend via new `set_geoip_path` command
- reload Tor manager when path changes

## Testing
- `cargo check` *(fails: glib not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686bc73322188333a748b13e31c65a3a