### PR TITLE
Fix worker import script

### DIFF
--- a/scripts/import_workers.ts
+++ b/scripts/import_workers.ts
@@ -1,6 +1,4 @@
-#!/usr/bin/env bun
 import { invoke } from '@tauri-apps/api/tauri';
-import { readFileSync } from 'fs';
 
 export async function importWorkers(content: string, token: string = '') {
   const workers = content
@@ -11,16 +9,8 @@ export async function importWorkers(content: string, token: string = '') {
   return workers.length;
 }
 
-async function main() {
-  const file = process.argv[2];
-  const token = process.argv[3] ?? '';
-  if (!file) {
-    console.error('Usage: import_workers.ts <file> [token]');
-    process.exit(1);
-  }
-  const content = readFileSync(file, 'utf-8');
-  const count = await importWorkers(content, token);
-  console.log(`Imported ${count} workers`);
+export async function importWorkersFromFile(path: string, token = '') {
+  const { readFileSync } = await import('fs');
+  const content = readFileSync(path, 'utf-8');
+  return importWorkers(content, token);
 }
-
-main();

--- a/scripts/import_workers_cli.ts
+++ b/scripts/import_workers_cli.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env bun
+import { importWorkersFromFile } from './import_workers.ts';
+
+async function main() {
+  const file = process.argv[2];
+  const token = process.argv[3] ?? '';
+  if (!file) {
+    console.error('Usage: import_workers_cli.ts <file> [token]');
+    process.exit(1);
+  }
+  const count = await importWorkersFromFile(file, token);
+  console.log(`Imported ${count} workers`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- refactor worker import module to avoid bundler errors
- split CLI helper to its own file for bun

## Testing
- `bun run build`
- `task mobile:android` *(fails: glib-2.0 not found)*
- `task mobile:ios` *(fails: glib-2.0 not found)*


------
https://chatgpt.com/codex/tasks/task_e_686bdabd7a248333a79c0586006f9b4b