### PR TITLE
Improve mobile build checks and HTTP bridge

### DIFF
--- a/mobile/scripts/build_android.sh
+++ b/mobile/scripts/build_android.sh
@@ -11,6 +11,16 @@ check_dep() {
 for cmd in bun cargo npx; do
   check_dep "$cmd"
 done
+
+if ! npx cap --version >/dev/null 2>&1; then
+  echo "Error: Capacitor CLI not found. Run 'bun install' first." >&2
+  exit 1
+fi
+
+if [ -z "$ANDROID_HOME" ] && [ -z "$ANDROID_SDK_ROOT" ] && ! command -v sdkmanager >/dev/null 2>&1; then
+  echo "Error: Android SDK not found. Please set ANDROID_HOME or ANDROID_SDK_ROOT." >&2
+  exit 1
+fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
 

--- a/mobile/scripts/build_ios.sh
+++ b/mobile/scripts/build_ios.sh
@@ -11,6 +11,11 @@ check_dep() {
 for cmd in bun cargo npx; do
   check_dep "$cmd"
 done
+
+if ! npx cap --version >/dev/null 2>&1; then
+  echo "Error: Capacitor CLI not found. Run 'bun install' first." >&2
+  exit 1
+fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
 

--- a/scripts/import_workers.ts
+++ b/scripts/import_workers.ts
@@ -1,16 +1,25 @@
-import { invoke } from '@tauri-apps/api/tauri';
+import { invoke } from "@tauri-apps/api/tauri";
 
-export async function importWorkers(content: string, token: string = '') {
+export async function importWorkers(content: string, token: string = "") {
   const workers = content
     .split(/\r?\n/)
     .map((l) => l.trim())
     .filter((l) => l.length > 0);
-  await invoke('set_worker_config', { workers, token });
+  const isMobile = typeof window !== "undefined" && (window as any).Capacitor;
+  if (isMobile) {
+    await fetch("http://127.0.0.1:1421/workers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ workers, token }),
+    });
+  } else {
+    await invoke("set_worker_config", { workers, token });
+  }
   return workers.length;
 }
 
-export async function importWorkersFromFile(path: string, token = '') {
-  const { readFileSync } = await import('fs');
-  const content = readFileSync(path, 'utf-8');
+export async function importWorkersFromFile(path: string, token = "") {
+  const { readFileSync } = await import("fs");
+  const content = readFileSync(path, "utf-8");
   return importWorkers(content, token);
 }

--- a/src-tauri/tests/http_bridge_tests.rs
+++ b/src-tauri/tests/http_bridge_tests.rs
@@ -93,3 +93,24 @@ async fn http_bridge_reports_connect() {
         .unwrap();
     assert_eq!(body, "CONNECTED");
 }
+
+#[cfg(feature = "mobile")]
+#[tokio::test]
+async fn http_bridge_sets_workers() {
+    let state = mock_state();
+    torwell84::http_bridge::start(state.clone());
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post("http://127.0.0.1:1421/workers")
+        .json(&serde_json::json!({
+            "workers": ["https://example.com"],
+            "token": "abc"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), reqwest::StatusCode::NO_CONTENT);
+}


### PR DESCRIPTION
## Summary
- verify Capacitor CLI & Android SDK before building mobile apps
- expose worker configuration via `/workers` in the mobile HTTP bridge
- let `importWorkers` use the HTTP bridge when running in a Capacitor shell
- add regression test for new HTTP bridge route

## Testing
- `bun run check` *(fails: `svelte-kit` not found)*
- `bun x svelte-check` *(fails: cannot find `@sveltejs/adapter-static`)*
- `bun audit` *(fails: script not found)*
- `bun run lint:a11y` *(fails: `svelte-kit` not found)*
- `cargo check` *(fails: missing `glib-2.0`)*
- `cargo clippy -- -D warnings` *(fails: missing `glib-2.0`)*
- `cargo test` *(fails: missing `glib-2.0`)*
- `cargo test --features mobile --test http_bridge_tests` *(fails: missing `glib-2.0`)*
- `task mobile:release` *(fails: `task` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be8252bbc8333838b2ad0f001fdb6