### PR TITLE
Improve status handling and toasts

### DIFF
--- a/src/lib/components/ActionCard.svelte
+++ b/src/lib/components/ActionCard.svelte
@@ -49,9 +49,10 @@
 
         $: isConnected = $torStore.status === 'CONNECTED';
         $: isStopped = $torStore.status === 'DISCONNECTED';
-        $: isConnecting = $torStore.status === 'CONNECTING' || $torStore.status === 'RETRYING';
-        $: isRetrying = $torStore.status === 'RETRYING';
-        $: isDisconnecting = $torStore.status === 'DISCONNECTING';
+       $: isConnecting = $torStore.status === 'CONNECTING' || $torStore.status === 'RETRYING';
+       $: isRetrying = $torStore.status === 'RETRYING';
+       $: isDisconnecting = $torStore.status === 'DISCONNECTING';
+       $: hasError = $torStore.status === 'ERROR';
 
 </script>
 
@@ -71,15 +72,15 @@
 
 	<!-- Four Buttons Layout -->
 	<div class="grid grid-cols-4 gap-3">
-		<!-- Connect/Disconnect Button -->
-		{#if isStopped}
-                        <button
-                                class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all duration-300 ease-in-out text-sm bg-green-600/20 text-green-200 hover:bg-green-600/30 border border-green-500/30 transform hover:scale-105"
-                                on:click={handleConnect}
-                                aria-label="Connect to Tor"
-                        >
-				<Play size={16} /> Connect
-			</button>
+               <!-- Connect/Disconnect Button -->
+               {#if isStopped || hasError}
+                       <button
+                               class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all duration-300 ease-in-out text-sm bg-green-600/20 text-green-200 hover:bg-green-600/30 border border-green-500/30 transform hover:scale-105"
+                               on:click={handleConnect}
+                               aria-label={hasError ? 'Retry connection' : 'Connect to Tor'}
+                       >
+                               <Play size={16} /> {hasError ? 'Retry' : 'Connect'}
+                       </button>
 		{:else if isConnecting}
 			<button
                                 class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 transition-all duration-300 ease-in-out text-sm bg-yellow-600/20 text-yellow-400 border border-yellow-500/30 opacity-75 cursor-not-allowed"

--- a/src/lib/components/IdlePanel.svelte
+++ b/src/lib/components/IdlePanel.svelte
@@ -1,9 +1,20 @@
 <script>
-        export let connectionProgress = 0; // 0-100
-        export let currentStatus = 'Idle'; // Current Tor status
-        export let retryCount = 0;
-        export let retryDelay = 0;
-        export let bootstrapMessage = '';
+export let connectionProgress = 0; // 0-100
+export let currentStatus = 'Idle'; // Current Tor status
+export let retryCount = 0;
+export let retryDelay = 0;
+export let bootstrapMessage = '';
+
+const statusMap: Record<string, string> = {
+    DISCONNECTED: 'Disconnected',
+    CONNECTING: 'Connecting',
+    RETRYING: 'Retrying',
+    CONNECTED: 'Connected',
+    DISCONNECTING: 'Disconnecting',
+    ERROR: 'Error',
+};
+
+$: statusText = statusMap[currentStatus] ?? currentStatus;
 
 	// Animation for status text changes
 	let isAnimating = false;
@@ -43,11 +54,13 @@
                         <p
                                 class="text-xs font-medium text-white absolute transition-all duration-300 {isAnimating ? 'opacity-0 transform scale-95' : 'opacity-100 transform scale-100'}"
                         >
-                                {currentStatus}
+                                {statusText}
                         </p>
                 </div>
                 {#if currentStatus === 'RETRYING'}
                         <p class="text-xs text-yellow-300">retry {retryCount} in {retryDelay}s</p>
+                {:else if currentStatus === 'ERROR'}
+                        <p class="text-xs text-red-300">connection failed</p>
                 {/if}
         </div>
 </div>

--- a/src/lib/components/NetworkTools.svelte
+++ b/src/lib/components/NetworkTools.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { invoke } from "$lib/api";
-  import { addToast } from "$lib/stores/toastStore";
+  import { addToast, addErrorToast } from "$lib/stores/toastStore";
   let host = "";
   let dns: string[] = [];
   let route: string[] = [];
@@ -22,9 +22,9 @@
     loading = true;
     try {
       dns = (await invoke("dns_lookup", { host })) as string[];
-    } catch (e) {
+    } catch (e: any) {
       dns = [];
-      addToast('DNS lookup failed', 'error');
+      addErrorToast('dns', e?.message ?? String(e));
     } finally {
       loading = false;
     }
@@ -35,9 +35,9 @@
     loading = true;
     try {
       route = (await invoke("traceroute_host", { host, maxHops: 8 })) as string[];
-    } catch (e) {
+    } catch (e: any) {
       route = [];
-      addToast('Traceroute failed', 'error');
+      addErrorToast('traceroute', e?.message ?? String(e));
     } finally {
       loading = false;
     }

--- a/src/lib/stores/toastStore.ts
+++ b/src/lib/stores/toastStore.ts
@@ -15,3 +15,26 @@ export function addToast(message: string, type: 'error' | 'info' = 'info', durat
     toasts.update((ts) => ts.filter((t) => t.id !== id));
   }, duration);
 }
+
+export type ErrorToastType = 'dns' | 'traceroute' | 'connection';
+
+export function addErrorToast(kind: ErrorToastType, detail?: string, duration = 5000) {
+  let message = '';
+  switch (kind) {
+    case 'dns':
+      message = 'DNS lookup failed';
+      break;
+    case 'traceroute':
+      message = 'Traceroute failed';
+      break;
+    case 'connection':
+      message = 'Connection error';
+      break;
+    default:
+      message = 'Error';
+  }
+  if (detail) {
+    message += `: ${detail}`;
+  }
+  addToast(message, 'error', duration);
+}


### PR DESCRIPTION
## Summary
- support `ERROR` state in ActionCard
- show readable status text in IdlePanel and include error messaging
- add toast helpers for common error types
- use `addErrorToast` for network tool failures

## Testing
- `bun run check` *(fails: svelte-check found errors)*
- `cargo test` *(fails: glib-2.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_686be826122083338f41ee6eec359489