### PR TITLE
Improve tray menu handling

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ rand = "0.8"
 surge-ping = "0.8"
 pkcs11 = { version = "0.5", optional = true }
 traceroute = "0.1.1"
+open = "5"
 
 [target.'cfg(windows)'.dependencies]
 winrt-notification = "0.5"


### PR DESCRIPTION
## Summary
- update tray menu dynamically when connection status changes
- keep warnings until the user confirms
- allow opening log and settings files from the tray

## Testing
- `cargo test -- --test-threads=1` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686be8211114833396901a3995383da2