### PR TITLE
Add central example configs

### DIFF
--- a/docs/ProductionCertificate.md
+++ b/docs/ProductionCertificate.md
@@ -1,6 +1,6 @@
 # Production Certificate
 
-This guide explains how to provide your own server certificate for Torwell84 deployments. The application pins a certificate and checks for updates at runtime. Follow these steps to prepare a production setup.
+This guide explains how to provide your own server certificate for Torwell84 deployments. The application pins a certificate and checks for updates at runtime. Example configuration files are located under `docs/examples`. Follow these steps to prepare a production setup.
 
 ## 1. Generate a Certificate
 
@@ -16,7 +16,7 @@ Place `server.pem` on your update server. Renew the file every 90 days.
 
 ## 2. Adjust `cert_config.json`
 
-Edit `src-tauri/certs/cert_config.json` and set `cert_url` to the HTTPS endpoint where `server.pem` is hosted. The repository no longer ships a certificate file. Place your production PEM in `/etc/torwell/server.pem` or adjust `cert_path` accordingly.
+Use the example configuration in `docs/examples/cert_config.json` as a template. Copy it to `src-tauri/certs/cert_config.json` and set `cert_url` to the HTTPS endpoint where `server.pem` is hosted. The repository no longer ships a certificate file. Place your production PEM in `/etc/torwell/server.pem` or adjust `cert_path` accordingly.
 
 ```json
 {

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -2,7 +2,8 @@
 
 Torwell84 can run as a systemd service on Linux systems.
 The repository provides a ready-to-use unit file at
-`src-tauri/torwell84.service`.
+`src-tauri/torwell84.service`. Example configuration files are available under
+`docs/examples`.
 
 ## Installation
 
@@ -31,7 +32,7 @@ reloads systemd and enables the service immediately.
 
 ## Certificate Configuration
 
-Edit `src-tauri/certs/cert_config.json` to point to your production update server:
+Copy `docs/examples/cert_config.json` to `src-tauri/certs/cert_config.json` and point it to your production update server:
 
 ```json
 {

--- a/docs/examples/app_config.json
+++ b/docs/examples/app_config.json
@@ -1,0 +1,7 @@
+{
+  "max_log_lines": 1000
+  ,"geoip_path": null
+  ,"hsm_lib": null
+  ,"hsm_slot": 0
+  ,"metrics_file": "metrics.json"
+}

--- a/docs/examples/cert_config.json
+++ b/docs/examples/cert_config.json
@@ -1,0 +1,8 @@
+{
+  "cert_path": "/etc/torwell/server.pem",
+  "cert_url": "https://updates.torwell.com/certs/server.pem",
+  "fallback_cert_url": null,
+  "min_tls_version": "1.2",
+  "update_interval": 86400,
+  "note": "Production certificate update endpoint"
+}


### PR DESCRIPTION
## Summary
- add new `docs/examples` directory
- copy `cert_config.json` and `app_config.json` examples there
- link to these examples from deployment docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bf31be1d88333a82d2010cac592b2