### PR TITLE
Add cross-platform release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,10 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - run: bun install
-      - run: bun run tauri build
+      - name: Build bundles
+        shell: bash
+        run: |
+          ./scripts/build_release.sh
       - name: Sign MSI
         if: matrix.os == 'windows-latest'
         env:

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -88,3 +88,7 @@ Depending on the operating system this produces:
 
 Copy the resulting package to the production machine and install it before
 enabling the systemd service.
+
+For official releases the GitHub workflow `release.yml` runs the same script on
+Windows, macOS and Linux runners. The generated bundles are signed (when
+secrets are available) and uploaded automatically to the GitHub Releases page.


### PR DESCRIPTION
## Summary
- use `scripts/build_release.sh` in the GitHub Release workflow
- mention automated releases in `ProductionDeployment.md`

## Testing
- `bun run check` *(fails: svelte-check found errors)*
- `cargo test` *(fails: glib-2.0.pc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf318a8c483338f697f69a5cb53c3