### PR TITLE
Add torwellctl CLI utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ src-tauri/Cargo.lock
 # UI backup directory created by scripts/backup_ui.sh
 src/lib/components_backup/
 
+!src-tauri/bin/

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -88,3 +88,16 @@ Depending on the operating system this produces:
 
 Copy the resulting package to the production machine and install it before
 enabling the systemd service.
+
+## Command Line Utility
+
+The release also includes the `torwellctl` binary for headless
+administration. It can import or export worker lists, trigger a manual
+certificate update and print stored metrics.
+
+```bash
+torwellctl import-workers workers.txt
+torwellctl export-workers
+torwellctl update-cert
+torwellctl show-metrics
+```

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ urlencoding = "2"
 base64 = "0.21"
 anyhow = "1"
 sysinfo = "0.30"
+clap = { version = "4", features = ["derive"] }
 governor = "0.10.0"
 axum = "0.7"
 directories = "6.0"
@@ -74,3 +75,7 @@ custom-protocol = ["tauri/custom-protocol"]
 mobile = []
 hsm = ["pkcs11"]
 experimental-api = ["arti-client/experimental-api"]
+
+[[bin]]
+name = "torwellctl"
+path = "bin/torwellctl.rs"

--- a/src-tauri/bin/torwellctl.rs
+++ b/src-tauri/bin/torwellctl.rs
@@ -1,0 +1,92 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use torwell84::secure_http::{SecureHttpClient, DEFAULT_CONFIG_PATH};
+use torwell84::state::AppState;
+
+#[derive(Parser)]
+#[command(
+    name = "torwellctl",
+    author,
+    version,
+    about = "Torwell84 command line utility"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Import a worker list from a text file
+    ImportWorkers {
+        /// Path to file with one URL per line
+        file: String,
+        /// Optional worker authentication token
+        #[arg(short, long)]
+        token: Option<String>,
+    },
+    /// Export currently configured workers
+    ExportWorkers,
+    /// Manually update pinned certificate
+    UpdateCert,
+    /// Display stored metrics
+    ShowMetrics,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Cli::parse();
+    let client = SecureHttpClient::init(DEFAULT_CONFIG_PATH, None, None, None, None).await?;
+    match args.command {
+        Commands::ImportWorkers { file, token } => {
+            let content = std::fs::read_to_string(file)?;
+            let workers: Vec<String> = content
+                .lines()
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+                .collect();
+            client.set_worker_config(workers.clone(), token).await;
+            println!("Imported {} workers", workers.len());
+        }
+        Commands::ExportWorkers => {
+            let workers = client.worker_urls().await;
+            for w in workers {
+                println!("{}", w);
+            }
+        }
+        Commands::UpdateCert => {
+            let cfg: serde_json::Value = std::fs::read_to_string(DEFAULT_CONFIG_PATH)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or_default();
+            let mut urls = vec![cfg
+                .get("cert_url")
+                .and_then(|v| v.as_str())
+                .unwrap_or(torwell84::secure_http::DEFAULT_CERT_URL)
+                .to_string()];
+            if let Some(fb) = cfg.get("fallback_cert_url").and_then(|v| v.as_str()) {
+                urls.push(fb.to_string());
+            }
+            if let Ok(env_url) = std::env::var("TORWELL_CERT_URL") {
+                urls[0] = env_url;
+            }
+            if let Ok(env_fb) = std::env::var("TORWELL_FALLBACK_CERT_URL") {
+                if urls.len() == 1 {
+                    urls.push(env_fb);
+                } else {
+                    urls[1] = env_fb;
+                }
+            }
+            client.update_certificates_from(&urls).await?;
+            println!("Certificate updated");
+        }
+        Commands::ShowMetrics => {
+            let state = AppState::new(client.clone());
+            let metrics = state.load_metrics().await?;
+            for m in metrics {
+                println!("{:#?}", m);
+            }
+        }
+    }
+    Ok(())
+}

--- a/src-tauri/src/secure_http.rs
+++ b/src-tauri/src/secure_http.rs
@@ -371,6 +371,11 @@ impl SecureHttpClient {
         *self.worker_token.lock().await = token;
     }
 
+    /// Retrieve the configured proxy workers
+    pub async fn worker_urls(&self) -> Vec<String> {
+        self.worker_urls.lock().await.clone()
+    }
+
     /// Update HSM library path and slot then reload TLS configuration
     pub async fn set_hsm_config(
         &self,


### PR DESCRIPTION
## Summary
- create `torwellctl` command line binary for worker management and metrics
- expose worker list retrieval in `SecureHttpClient`
- include new binary in Cargo configuration and add Clap
- document basic usage

## Testing
- `cargo fmt --all`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bf3176bd88333970fdefb310323c3