### PR TITLE
Add environment setup script and integrate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,11 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-      - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev pkg-config
+      - name: Setup environment
+        run: ./scripts/setup_env.sh
+      - name: Run cargo check
+        working-directory: src-tauri
+        run: cargo check
       - name: Run cargo test
         working-directory: src-tauri
         run: cargo test
@@ -52,6 +53,8 @@ jobs:
         with:
           bun-version: latest
       - run: bun install
+      - name: Setup environment
+        run: ./scripts/setup_env.sh
       - run: bun run check
       - name: Run svelte-check
         run: bunx svelte-check
@@ -96,6 +99,9 @@ jobs:
         with:
           bun-version: latest
       - run: bun install
+      - name: Setup environment
+        shell: bash
+        run: ./scripts/setup_env.sh
       - run: bun run check
       - name: Run svelte-check
         run: bunx svelte-check

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -80,6 +80,13 @@ Run the release task on the target platform to create the installer packages.
 task release   # invokes scripts/build_release.sh
 ```
 
+Before building on a fresh Linux machine execute the helper script to install
+all required system libraries:
+
+```bash
+./scripts/setup_env.sh
+```
+
 Depending on the operating system this produces:
 
 - Windows: an `.msi` installer in `src-tauri/target/release/bundle/msi`

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$(uname)" != "Linux" ]; then
+  echo "setup_env.sh is intended for Linux systems only."
+  exit 0
+fi
+
+sudo apt-get update
+sudo apt-get install -y \
+  libglib2.0-dev \
+  libgtk-3-dev \
+  libwebkit2gtk-4.1-dev \
+  libssl-dev \
+  libayatana-appindicator3-dev \
+  librsvg2-dev \
+  pkg-config


### PR DESCRIPTION
## Summary
- create `scripts/setup_env.sh` to install Linux deps
- run setup script before cargo and bun checks in CI
- document the setup script in ProductionDeployment guide

## Testing
- `bun install`
- `bun run check` *(fails: svelte-check reported errors)*
- `cargo check` *(fails: missing `glib-2.0` system library)*

------
https://chatgpt.com/codex/tasks/task_e_686bf3142dc08333b0eb61fd1687976c