### PR TITLE
Add setup script and docs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,6 +14,7 @@ tasks:
     desc: "Install all frontend and backend dependencies."
     cmds:
       - bun install
+      - bun add -d @sveltejs/kit
 
   dev:
     desc: "Starts the application in development mode with hot-reloading."

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -14,6 +14,16 @@ This guide lists common problems encountered during development and how to analy
 - **Dependencies not installed**: If the frontend will not build, run `bun install` to fetch Node packages.
 - **Build errors**: Ensure `bun run check` and `cargo check` succeed before opening a pull request.
 
+## Node-Tools installieren
+
+Das Projekt verwendet Bun als Paketmanager und SvelteKit für das Frontend. Führe einmalig
+
+```bash
+task setup    # oder: bun run setup
+```
+
+aus, um `bun install` und die Installation von `@sveltejs/kit` automatisch zu starten.
+
 ## Debugging & Log Analysis
 
 - Start the app in development mode with `bun tauri dev` to view live output.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "tauri:build": "tauri build",
     "lint:a11y": "svelte-kit sync && svelte-check --output human-verbose",
     "test": "vitest run",
-    "backup:ui": "bash scripts/backup_ui.sh"
+    "backup:ui": "bash scripts/backup_ui.sh",
+    "setup": "bun install && bun add -d @sveltejs/kit"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.1",


### PR DESCRIPTION
## Summary
- add `setup` script to package.json
- extend `task setup` to install @sveltejs/kit
- document how to install node tools

## Testing
- `bun run setup`
- `bun run check` *(fails: svelte-check found errors)*
- `bun test` *(fails: vitest errors)*
- `cargo check` *(fails: glib-2.0 missing)*


------
https://chatgpt.com/codex/tasks/task_e_686bf3156b5c8333b183385420d5e987