### PR TITLE
Add lookup_country command

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -634,6 +634,16 @@ pub async fn traceroute_host(
 }
 
 #[tauri::command]
+pub async fn lookup_country(state: State<'_, AppState>, ip: String) -> Result<String> {
+    track_call("lookup_country").await;
+    check_api_rate()?;
+    {
+        let mgr = state.tor_manager.read().await.clone();
+        mgr.lookup_country_code(&ip).await
+    }
+}
+
+#[tauri::command]
 pub async fn get_secure_key(state: State<'_, AppState>, token: String) -> Result<Option<String>> {
     track_call("get_secure_key").await;
     check_api_rate()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -198,6 +198,7 @@ pub fn run() {
             commands::ping_host_series,
             commands::dns_lookup,
             commands::traceroute_host,
+            commands::lookup_country,
             commands::get_secure_key,
             commands::set_secure_key,
             commands::reconnect,

--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -352,3 +352,14 @@ async fn tray_warning_set_and_cleared() {
     state.clear_tray_warning().await;
     assert!(state.tray_warning.lock().await.is_none());
 }
+
+#[tokio::test]
+async fn command_lookup_country() {
+    let mut app = tauri::test::mock_app();
+    app.manage(mock_state());
+    let state = app.state::<AppState<MockTorClient>>();
+    let code = commands::lookup_country(state, "8.8.8.8".into())
+        .await
+        .unwrap();
+    assert!(!code.is_empty());
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -29,3 +29,7 @@ export async function invoke(
     throw err;
   }
 }
+
+export function lookupCountry(ip: string) {
+  return invoke('lookup_country', { ip }) as Promise<string>;
+}

--- a/src/lib/components/NetworkTools.svelte
+++ b/src/lib/components/NetworkTools.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke } from "$lib/api";
+  import { invoke, lookupCountry } from "$lib/api";
   import { addToast, addErrorToast } from "$lib/stores/toastStore";
   let host = "";
   let dns: string[] = [];
@@ -7,17 +7,6 @@
   let countries: string[] = [];
   let loading = false;
 
-  async function lookupCountry(ip: string): Promise<string> {
-    try {
-      const res = await fetch(`https://ipapi.co/${ip}/country/`);
-      if (res.ok) {
-        return (await res.text()).trim();
-      }
-    } catch (_) {
-      // ignore
-    }
-    return "??";
-  }
 
   function copyDns() {
     navigator.clipboard.writeText(dns.join('\n'));


### PR DESCRIPTION
## Summary
- introduce `lookup_country` Tauri command and register handler
- expose lookupCountry helper in API
- reuse lookupCountry in NetworkTools
- add basic command test

## Testing
- `cargo test command_lookup_country -- --test-threads=1` *(fails: glib-2.0 missing)*
- `bun run test` *(fails: several vitest tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_686bfd289e708333a4a9ea39eed4b582