### PR TITLE
Improve mobile build scripts

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -23,16 +23,16 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: task mobile:android
-      - name: Find APK
+      - name: Collect APK
         id: apk
         run: |
-          APK=$(find . -name '*.apk' | head -n 1 || true)
+          APK=$(ls mobile/android/*.apk 2>/dev/null | head -n 1 || true)
           if [ -z "$APK" ]; then
             echo "Creating placeholder APK"
-            mkdir -p dist
-            echo "APK missing" > dist/placeholder.txt
-            zip -j dist/placeholder.apk.zip dist/placeholder.txt
-            echo "path=dist/placeholder.apk.zip" >> "$GITHUB_OUTPUT"
+            mkdir -p mobile/dist
+            echo "APK missing" > mobile/dist/placeholder.txt
+            zip -j mobile/dist/placeholder.apk.zip mobile/dist/placeholder.txt
+            echo "path=mobile/dist/placeholder.apk.zip" >> "$GITHUB_OUTPUT"
           else
             echo "path=$APK" >> "$GITHUB_OUTPUT"
           fi
@@ -41,6 +41,7 @@ jobs:
         with:
           name: android-apk
           path: ${{ steps.apk.outputs.path }}
+          if-no-files-found: error
 
   ios:
     runs-on: macos-latest
@@ -57,16 +58,16 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: task mobile:ios
-      - name: Find IPA
+      - name: Collect IPA
         id: ipa
         run: |
-          IPA=$(find . -name '*.ipa' | head -n 1 || true)
+          IPA=$(ls mobile/ios/*.ipa 2>/dev/null | head -n 1 || true)
           if [ -z "$IPA" ]; then
             echo "Creating placeholder IPA"
-            mkdir -p dist
-            echo "IPA missing" > dist/placeholder.txt
-            zip -j dist/placeholder.ipa.zip dist/placeholder.txt
-            echo "path=dist/placeholder.ipa.zip" >> "$GITHUB_OUTPUT"
+            mkdir -p mobile/dist
+            echo "IPA missing" > mobile/dist/placeholder.txt
+            zip -j mobile/dist/placeholder.ipa.zip mobile/dist/placeholder.txt
+            echo "path=mobile/dist/placeholder.ipa.zip" >> "$GITHUB_OUTPUT"
           else
             echo "path=$IPA" >> "$GITHUB_OUTPUT"
           fi
@@ -75,3 +76,4 @@ jobs:
         with:
           name: ios-ipa
           path: ${{ steps.ipa.outputs.path }}
+          if-no-files-found: error

--- a/docs/Mobile.md
+++ b/docs/Mobile.md
@@ -79,6 +79,8 @@ task mobile:release  # erstellt beide Pakete
 Die fertigen Dateien landen im Verzeichnis `mobile/dist`. Nach erfolgreichem
 Lauf findest du das Android‑APK im Ordner `mobile/android/app/build/outputs/apk/`.
 Für iOS wird ein Xcode-Projekt unter `mobile/ios` erzeugt.
+Nach einem Build kannst du mit `./mobile/scripts/test_artifacts.sh` 
+prüfen, ob die APK- bzw. IPA-Datei korrekt erstellt wurde.
 
 ## Testing the final builds
 

--- a/mobile/scripts/build_android.sh
+++ b/mobile/scripts/build_android.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+trap 'echo "[ERROR] Build failed at line $LINENO" >&2' ERR
 
 check_dep() {
   if ! command -v "$1" >/dev/null 2>&1; then
-    echo "Error: '$1' is required but not installed." >&2
+    echo "[ERROR] '$1' is required but not installed." >&2
     exit 1
   fi
+}
+
+msg() {
+  echo "[INFO] $*"
 }
 
 for cmd in bun cargo npx; do
@@ -13,42 +19,45 @@ for cmd in bun cargo npx; do
 done
 
 if ! npx cap --version >/dev/null 2>&1; then
-  echo "Error: Capacitor CLI not found. Run 'bun install' first." >&2
+  echo "[ERROR] Capacitor CLI not found. Run 'bun install' first." >&2
   exit 1
 fi
 
-if [ -z "$ANDROID_HOME" ] && [ -z "$ANDROID_SDK_ROOT" ] && ! command -v sdkmanager >/dev/null 2>&1; then
-  echo "Error: Android SDK not found. Please set ANDROID_HOME or ANDROID_SDK_ROOT." >&2
+if [ -z "${ANDROID_HOME:-}" ] && [ -z "${ANDROID_SDK_ROOT:-}" ] && ! command -v sdkmanager >/dev/null 2>&1; then
+  echo "[ERROR] Android SDK not found. Please set ANDROID_HOME or ANDROID_SDK_ROOT." >&2
   exit 1
 fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
-
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Build the Svelte frontend only if the build directory doesn't exist
 if [ -d "$ROOT_DIR/build" ]; then
-  echo "Reusing existing frontend build at $ROOT_DIR/build"
+  msg "Reusing existing frontend build at $ROOT_DIR/build"
 else
+  msg "Building frontend"
   (cd "$ROOT_DIR" && bun run build)
 fi
 
-# Compile the Rust backend with the `mobile` feature so the HTTP bridge is
-# available when the app runs.
+# Compile the Rust backend with the `mobile` feature so the HTTP bridge is available when the app runs.
+msg "Compiling Rust backend"
 cargo build --release --manifest-path "$ROOT_DIR/src-tauri/Cargo.toml" --features mobile
 
 # Build the Android app using Capacitor
 cd "$SCRIPT_DIR/.."
 bun install
+msg "Copying assets"
 npx cap copy android
+msg "Building Android project"
 npx cap build android
 
-# Copy the generated APK to a predictable location
-APK_PATH=$(find android/app/build/outputs/apk -name "*.apk" | head -n 1 || true)
-if [ -n "$APK_PATH" ]; then
+APK_PATH=$(find android/app/build/outputs/apk -name '*.apk' | head -n 1 || true)
+if [ -n "$APK_PATH" ] && [ -f "$APK_PATH" ]; then
   DEST_DIR="$SCRIPT_DIR/../android"
   mkdir -p "$DEST_DIR"
   cp "$APK_PATH" "$DEST_DIR/"
-  echo "APK copied to $DEST_DIR/$(basename "$APK_PATH")"
+  msg "APK copied to $DEST_DIR/$(basename "$APK_PATH")"
 else
-  echo "No APK produced" >&2
+  echo "[ERROR] No APK produced" >&2
+  exit 1
 fi

--- a/mobile/scripts/build_ios.sh
+++ b/mobile/scripts/build_ios.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+trap 'echo "[ERROR] Build failed at line $LINENO" >&2' ERR
 
 check_dep() {
   if ! command -v "$1" >/dev/null 2>&1; then
-    echo "Error: '$1' is required but not installed." >&2
+    echo "[ERROR] '$1' is required but not installed." >&2
     exit 1
   fi
+}
+
+msg() {
+  echo "[INFO] $*"
 }
 
 for cmd in bun cargo npx; do
@@ -13,37 +19,40 @@ for cmd in bun cargo npx; do
 done
 
 if ! npx cap --version >/dev/null 2>&1; then
-  echo "Error: Capacitor CLI not found. Run 'bun install' first." >&2
+  echo "[ERROR] Capacitor CLI not found. Run 'bun install' first." >&2
   exit 1
 fi
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(dirname "$SCRIPT_DIR")/.."
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Build the Svelte frontend only if the build directory doesn't exist
 if [ -d "$ROOT_DIR/build" ]; then
-  echo "Reusing existing frontend build at $ROOT_DIR/build"
+  msg "Reusing existing frontend build at $ROOT_DIR/build"
 else
+  msg "Building frontend"
   (cd "$ROOT_DIR" && bun run build)
 fi
 
-# Compile the Rust backend with the `mobile` feature so the HTTP bridge is
-# available when the app runs.
+# Compile the Rust backend with the `mobile` feature so the HTTP bridge is available when the app runs.
+msg "Compiling Rust backend"
 cargo build --release --manifest-path "$ROOT_DIR/src-tauri/Cargo.toml" --features mobile
 
 # Build the iOS app using Capacitor
 cd "$SCRIPT_DIR/.."
 bun install
+msg "Copying assets"
 npx cap copy ios
+msg "Building iOS project"
 npx cap build ios
 
-# Copy the generated IPA to a predictable location
-IPA_PATH=$(find ios -name "*.ipa" | head -n 1 || true)
-if [ -n "$IPA_PATH" ]; then
+IPA_PATH=$(find ios -name '*.ipa' | head -n 1 || true)
+if [ -n "$IPA_PATH" ] && [ -f "$IPA_PATH" ]; then
   DEST_DIR="$SCRIPT_DIR/../ios"
   mkdir -p "$DEST_DIR"
   cp "$IPA_PATH" "$DEST_DIR/"
-  echo "IPA copied to $DEST_DIR/$(basename "$IPA_PATH")"
+  msg "IPA copied to $DEST_DIR/$(basename "$IPA_PATH")"
 else
-  echo "No IPA produced" >&2
+  echo "[ERROR] No IPA produced" >&2
+  exit 1
 fi

--- a/mobile/scripts/test_artifacts.sh
+++ b/mobile/scripts/test_artifacts.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APK=$(ls mobile/android/*.apk 2>/dev/null || true)
+IPA=$(ls mobile/ios/*.ipa 2>/dev/null || true)
+
+status=0
+
+if [ -n "$APK" ]; then
+  echo "Found APK: $APK"
+else
+  echo "APK not found in mobile/android" >&2
+  status=1
+fi
+
+if [ -n "$IPA" ]; then
+  echo "Found IPA: $IPA"
+else
+  echo "IPA not found in mobile/ios" >&2
+  status=1
+fi
+
+exit $status


### PR DESCRIPTION
## Summary
- add clearer logging and error checks to Android and iOS build scripts
- upload artifacts from fixed paths in the mobile workflow
- mention new verification script in the docs
- provide simple test script for APK/IPA presence

## Testing
- `bun test` *(fails: Cannot find module '@testing-library/svelte')*
- `bash mobile/scripts/test_artifacts.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c35aac6ac8333b7a42f084b4b8c0f