### PR TITLE
Improve service installation

### DIFF
--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -7,12 +7,13 @@ The repository provides a ready-to-use unit file at
 
 ## Installation
 
-Copy the file to your systemd directory and enable the service:
+Copy the unit file to your systemd directory and enable the service:
 
 ```bash
 sudo cp src-tauri/torwell84.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now torwell84.service
+sudo systemctl status torwell84.service
 ```
 
 The service starts `/opt/torwell84/torwell84` as the `torwell` user and group
@@ -21,14 +22,20 @@ and restarts automatically on failure. Logs are available with
 
 ## Service Installation
 
-Instead of running the commands manually you can use the helper script:
+Instead of running the commands manually you can use the helper script. It
+validates the target directory and prints the service status after enabling it:
 
 ```bash
 sudo ./scripts/install_service.sh
 ```
 
 The script copies `src-tauri/torwell84.service` into `/etc/systemd/system/`,
-reloads systemd and enables the service immediately.
+reloads systemd and enables the service immediately. A lightweight test harness
+is available to simulate the installation without touching real system files:
+
+```bash
+./scripts/test_service_install.sh
+```
 
 ## Certificate Configuration
 

--- a/scripts/test_service_install.sh
+++ b/scripts/test_service_install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+TMP_DIR=$(mktemp -d)
+FAKE_SYSTEMCTL="$TMP_DIR/systemctl"
+
+# create a fake systemctl that just echoes the arguments
+cat > "$FAKE_SYSTEMCTL" <<'SCRIPT'
+#!/usr/bin/env bash
+echo "systemctl $@"
+SCRIPT
+chmod +x "$FAKE_SYSTEMCTL"
+
+export TARGET_DIR="$TMP_DIR"
+export SYSTEMCTL="$FAKE_SYSTEMCTL"
+export SUDO=""
+
+./scripts/install_service.sh
+
+if [ -f "$TMP_DIR/torwell84.service" ]; then
+  echo "Service file installed in $TMP_DIR"
+else
+  echo "Service installation failed" >&2
+  exit 1
+fi
+
+echo "Test completed successfully"

--- a/src-tauri/torwell84.service
+++ b/src-tauri/torwell84.service
@@ -4,10 +4,13 @@ After=network-online.target
 
 [Service]
 Type=simple
+# Ensure the binary exists before attempting to start
+ExecStartPre=/usr/bin/test -x /opt/torwell84/torwell84
 ExecStart=/opt/torwell84/torwell84
-Restart=always
+Restart=on-failure
 User=torwell
 Group=torwell
+WorkingDirectory=/opt/torwell84
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- validate service install paths and show status output
- add a simple test script simulating the installation
- check the binary before launching in the service file
- document the new behaviour and test harness

## Testing
- `bash scripts/test_service_install.sh`
- `npm test` *(fails: FaultyComponent, SettingsModal, database tests)*

------
https://chatgpt.com/codex/tasks/task_e_686c3d3fbaa883338a2ec541be92fc0c