### PR TITLE
Update to v2.4.0

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,3 +1,15 @@
+## [2.4.0] - 2025-07-08
+- Worker queue uses VecDeque with configurable metrics interval
+- Improved service installation and docs
+- Improved worker import with tests
+- Updated mobile build scripts and workflow
+- Better HSM error messages and docs
+- Updated certificate configuration example
+- Auto refresh tray menu on status changes
+- Detailed error handling with new tests
+- lookup_country command integration
+- Metrics rotation and trimming with scheduled cert updates
+
 ## [2.3.1] - 2025-07-07
 - docs: update task list
 - Add metrics persistence

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torwell84-v2-ui",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torwell84"
-version = "2.3.1"
+version = "2.4.0"
 description = "Torwell84 V2 - A modern, secure Tor network management application"
 authors = ["Kilo Code"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Torwell84 V2",
-    "version": "2.3.1"
+    "version": "2.4.0"
   },
   "tauri": {
     "bundle": {


### PR DESCRIPTION
## Summary
- bump version numbers to 2.4.0
- document latest features in Changelog

## Testing
- `bun run test` *(fails: vitest not installed)*
- `cargo test` *(fails: could not download crates before aborting)*

------
https://chatgpt.com/codex/tasks/task_e_686c53f4de3483338e01d23652b23773