### PR TITLE
Improve connection error handling

### DIFF
--- a/src-tauri/tests/commands_tests.rs
+++ b/src-tauri/tests/commands_tests.rs
@@ -410,6 +410,36 @@ async fn command_connect_error_propagates_details() {
     assert!(!events.is_empty());
     let last: serde_json::Value = serde_json::from_str(&events[events.len() - 1]).unwrap();
     assert_eq!(last["status"], "ERROR");
-    assert_eq!(last["errorStep"], "retries_exceeded");
-    assert!(last["errorSource"].as_str().unwrap().contains("bootstrap"));
+    assert_eq!(last["errorStep"], "bootstrap");
+    assert!(last["errorSource"].as_str().unwrap().contains("retries exceeded"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn command_connect_retry_event_contains_details() {
+    for _ in 0..2 {
+        MockTorClient::push_result(Err("boot".into()));
+    }
+    let mut app = tauri::test::mock_app();
+    app.manage(mock_state());
+    let received = Arc::new(StdMutex::new(Vec::new()));
+    let recv_clone = received.clone();
+    let _handler = app.listen_global("tor-status-update", move |event| {
+        if let Some(p) = event.payload() {
+            recv_clone.lock().unwrap().push(p.to_string());
+        }
+    });
+    let state = app.state::<AppState<MockTorClient>>();
+    commands::connect(app.handle(), state).await.unwrap();
+
+    advance(Duration::from_secs(10)).await;
+    tokio::task::yield_now().await;
+
+    let events = received.lock().unwrap();
+    let retry: serde_json::Value = events
+        .iter()
+        .filter_map(|e| serde_json::from_str::<serde_json::Value>(e).ok())
+        .find(|v| v["status"] == "RETRYING")
+        .expect("retry event missing");
+    assert_eq!(retry["errorStep"], "bootstrap");
+    assert!(retry["errorSource"].as_str().unwrap().contains("boot"));
 }

--- a/src-tauri/tests/tor_manager_tests.rs
+++ b/src-tauri/tests/tor_manager_tests.rs
@@ -85,9 +85,9 @@ async fn connect_with_backoff_error() {
         .await;
     match res {
         Err(Error::ConnectionFailed { step, source, .. }) => {
-            assert_eq!(step, "retries_exceeded");
+            assert_eq!(step, "bootstrap");
+            assert!(source.contains("retries exceeded"));
             assert!(source.contains("e2"));
-            assert!(source.contains("bootstrap"));
         }
         _ => panic!("expected connection failure"),
     }
@@ -114,9 +114,9 @@ async fn connect_with_backoff_timeout() {
         .await;
     match res {
         Err(Error::ConnectionFailed { step, source, .. }) => {
-            assert_eq!(step, "timeout");
+            assert_eq!(step, "bootstrap");
+            assert!(source.contains("timeout"));
             assert!(source.contains("e1"));
-            assert!(source.contains("bootstrap"));
         }
         _ => panic!("expected timeout error"),
     }

--- a/src/lib/stores/torStore.ts
+++ b/src/lib/stores/torStore.ts
@@ -127,7 +127,15 @@ function createTorStore() {
 
     const newStatus =
       (event.payload.status as TorStatus) ?? initialState.status;
-    if (newStatus !== "CONNECTED") {
+    if (newStatus === "CONNECTED") {
+      update((state) => ({
+        ...state,
+        securityWarning: null,
+        errorMessage: null,
+        errorStep: null,
+        errorSource: null,
+      }));
+    } else {
       update((state) => ({
         ...state,
         memoryUsageMB: 0,


### PR DESCRIPTION
## Summary
- propagate the last failing step in `connect_with_backoff`
- forward context to the UI
- reset warnings when Tor connects
- extend tests for new error reporting

## Testing
- `cargo test` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c6034649c83339e7ab6f16fdd3520