### PR TITLE
Ensure tray menu rebuilds fully

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -80,10 +80,6 @@ pub fn run() {
                         }
                         state.update_tray_menu().await;
                     });
-                    let st = app.state::<AppState>();
-                    tauri::async_runtime::spawn(async move {
-                        st.update_tray_menu().await;
-                    });
                 }
                 "disconnect" => {
                     let state = app.state::<AppState>();
@@ -93,10 +89,6 @@ pub fn run() {
                             log::error!("tray disconnect failed: {}", e);
                         }
                         state.update_tray_menu().await;
-                    });
-                    let st = app.state::<AppState>();
-                    tauri::async_runtime::spawn(async move {
-                        st.update_tray_menu().await;
                     });
                 }
                 "reconnect" => {


### PR DESCRIPTION
## Summary
- rebuild the tray menu from scratch every time
- refresh tray menu right after connect and disconnect
- test tray warning set, clear and rebuild behavior

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c6035242c8333b5ac94374fb02eb6