### PR TITLE
Improve mobile build scripts and workflow

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -23,6 +23,7 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: task mobile:android
+      - run: ./mobile/scripts/test_artifacts.sh android
       - name: Collect APK
         id: apk
         run: |
@@ -58,6 +59,7 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: task mobile:ios
+      - run: ./mobile/scripts/test_artifacts.sh ios
       - name: Collect IPA
         id: ipa
         run: |

--- a/mobile/scripts/build_android.sh
+++ b/mobile/scripts/build_android.sh
@@ -6,25 +6,33 @@ trap 'echo "[ERROR] Build failed at line $LINENO" >&2' ERR
 check_dep() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "[ERROR] '$1' is required but not installed." >&2
-    exit 1
+    missing=1
   fi
 }
+
+
+missing=0
 
 msg() {
   echo "[INFO] $*"
 }
 
-for cmd in bun cargo npx; do
+for cmd in bun cargo npx java gradle; do
   check_dep "$cmd"
 done
 
 if ! npx cap --version >/dev/null 2>&1; then
   echo "[ERROR] Capacitor CLI not found. Run 'bun install' first." >&2
-  exit 1
+  missing=1
 fi
 
 if [ -z "${ANDROID_HOME:-}" ] && [ -z "${ANDROID_SDK_ROOT:-}" ] && ! command -v sdkmanager >/dev/null 2>&1; then
   echo "[ERROR] Android SDK not found. Please set ANDROID_HOME or ANDROID_SDK_ROOT." >&2
+  missing=1
+fi
+
+if [ "$missing" -eq 1 ]; then
+  echo "[ERROR] Missing dependencies detected. Aborting." >&2
   exit 1
 fi
 

--- a/mobile/scripts/build_ios.sh
+++ b/mobile/scripts/build_ios.sh
@@ -6,20 +6,28 @@ trap 'echo "[ERROR] Build failed at line $LINENO" >&2' ERR
 check_dep() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "[ERROR] '$1' is required but not installed." >&2
-    exit 1
+    missing=1
   fi
 }
+
+
+missing=0
 
 msg() {
   echo "[INFO] $*"
 }
 
-for cmd in bun cargo npx; do
+for cmd in bun cargo npx xcodebuild pod; do
   check_dep "$cmd"
 done
 
 if ! npx cap --version >/dev/null 2>&1; then
   echo "[ERROR] Capacitor CLI not found. Run 'bun install' first." >&2
+  missing=1
+fi
+
+if [ "$missing" -eq 1 ]; then
+  echo "[ERROR] Missing dependencies detected. Aborting." >&2
   exit 1
 fi
 

--- a/mobile/scripts/test_artifacts.sh
+++ b/mobile/scripts/test_artifacts.sh
@@ -1,23 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+TYPE=${1:-all}
 APK=$(ls mobile/android/*.apk 2>/dev/null || true)
 IPA=$(ls mobile/ios/*.ipa 2>/dev/null || true)
 
 status=0
 
-if [ -n "$APK" ]; then
-  echo "Found APK: $APK"
-else
-  echo "APK not found in mobile/android" >&2
-  status=1
+if [ "$TYPE" != "ios" ]; then
+  if [ -n "$APK" ]; then
+    echo "Found APK: $APK"
+  else
+    echo "APK not found in mobile/android" >&2
+    status=1
+  fi
 fi
 
-if [ -n "$IPA" ]; then
-  echo "Found IPA: $IPA"
-else
-  echo "IPA not found in mobile/ios" >&2
-  status=1
+if [ "$TYPE" != "android" ]; then
+  if [ -n "$IPA" ]; then
+    echo "Found IPA: $IPA"
+  else
+    echo "IPA not found in mobile/ios" >&2
+    status=1
+  fi
 fi
 
 exit $status


### PR DESCRIPTION
## Summary
- harden dependency checks in `build_android.sh` and `build_ios.sh`
- allow `test_artifacts.sh` to check only a single platform
- call the artifact check in the mobile CI workflow
- keep `capacitor.config.ts` pointing at `../build`

## Testing
- `bun test` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686c6037c158833398d93fc161dc0884