### PR TITLE
Improve service install scripts and docs

### DIFF
--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -36,6 +36,21 @@ is available to simulate the installation without touching real system files:
 ```bash
 ./scripts/test_service_install.sh
 ```
+Running the script prints the commands that would be executed and a brief
+status report:
+
+```text
+Installing service file to /tmp/tmp.XYZ
+systemctl daemon-reload
+Enabling and starting torwell84.service
+systemctl enable --now torwell84.service
+Service status:
+\u25cf torwell84.service - Fake Service
+   Loaded: loaded (/tmp/tmp.XYZ/torwell84.service; enabled)
+   Active: active (running)
+Service file installed in /tmp/tmp.XYZ
+Test completed successfully
+```
 
 ## Certificate Configuration
 

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -4,8 +4,9 @@ set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SERVICE_FILE="$ROOT_DIR/src-tauri/torwell84.service"
 TARGET_DIR="${TARGET_DIR:-/etc/systemd/system}"
+export TARGET_DIR
 SYSTEMCTL="${SYSTEMCTL:-systemctl}"
-SUDO="${SUDO:-sudo}"
+SUDO="${SUDO-sudo}"
 
 # Basic path validation
 if [ ! -f "$SERVICE_FILE" ]; then
@@ -42,5 +43,6 @@ $SUDO $SYSTEMCTL daemon-reload
 echo "Enabling and starting torwell84.service"
 $SUDO $SYSTEMCTL enable --now torwell84.service
 
-echo "Service status:" 
-$SUDO $SYSTEMCTL --no-pager status torwell84.service | head -n 10
+echo "Service status:"
+$SUDO $SYSTEMCTL --no-pager status torwell84.service
+

--- a/scripts/test_service_install.sh
+++ b/scripts/test_service_install.sh
@@ -4,10 +4,17 @@ set -e
 TMP_DIR=$(mktemp -d)
 FAKE_SYSTEMCTL="$TMP_DIR/systemctl"
 
-# create a fake systemctl that just echoes the arguments
 cat > "$FAKE_SYSTEMCTL" <<'SCRIPT'
 #!/usr/bin/env bash
+if [ "$1" = "--no-pager" ]; then
+  shift
+fi
 echo "systemctl $@"
+if [ "$1" = "status" ]; then
+  echo "\u25cf torwell84.service - Fake Service"
+  echo "   Loaded: loaded ($TARGET_DIR/torwell84.service; enabled)"
+  echo "   Active: active (running)"
+fi
 SCRIPT
 chmod +x "$FAKE_SYSTEMCTL"
 
@@ -25,3 +32,4 @@ else
 fi
 
 echo "Test completed successfully"
+


### PR DESCRIPTION
## Summary
- tweak `install_service.sh` to export TARGET_DIR and show full status
- add script `test_service_install.sh` to simulate service installation
- document the test harness with example output

## Testing
- `./scripts/test_service_install.sh`
- `bun run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6038ffec8333a1196c0b60d18c9b