### PR TITLE
Improve error handling and UI reporting

### DIFF
--- a/src/__tests__/IdlePanel.spec.ts
+++ b/src/__tests__/IdlePanel.spec.ts
@@ -30,4 +30,18 @@ describe('IdlePanel', () => {
     expect(getByText('Starting')).toBeInTheDocument();
     expect(getByText(/retry 2 in 5s/i)).toBeInTheDocument();
   });
+
+  it('displays error details', () => {
+    const { getByText } = render(IdlePanel, {
+      props: {
+        connectionProgress: 0,
+        currentStatus: 'ERROR',
+        errorStep: 'bootstrap',
+        errorSource: 'timeout'
+      }
+    });
+
+    expect(getByText(/bootstrap/i)).toBeInTheDocument();
+    expect(getByText(/timeout/i)).toBeInTheDocument();
+  });
 });

--- a/src/lib/components/ActionCard.svelte
+++ b/src/lib/components/ActionCard.svelte
@@ -1,147 +1,171 @@
 <script>
-	import { Activity, Settings, Play, Square, RotateCcw, RefreshCw, AlertCircle } from 'lucide-svelte';
-	import { createEventDispatcher } from 'svelte';
-	
-	import { torStore } from '$lib/stores/torStore';
-	import { invoke } from '@tauri-apps/api';
+  import {
+    Activity,
+    Settings,
+    Play,
+    Square,
+    RotateCcw,
+    RefreshCw,
+    AlertCircle,
+  } from "lucide-svelte";
+  import { createEventDispatcher } from "svelte";
 
-	let connectError = null;
+  import { torStore } from "$lib/stores/torStore";
+  import { invoke } from "@tauri-apps/api";
 
-	const dispatch = createEventDispatcher();
+  let connectError = null;
 
-	let isCreatingCircuit = false;
-	let isCreatingIdentity = false;
+  const dispatch = createEventDispatcher();
 
-	async function handleConnect() {
-		await invoke('connect');
-	}
+  let isCreatingCircuit = false;
+  let isCreatingIdentity = false;
 
-	async function handleDisconnect() {
-		await invoke('disconnect');
-	}
+  async function handleConnect() {
+    await invoke("connect");
+  }
 
-	async function handleNewCircuit() {
-		if (!isConnected || isCreatingCircuit) return;
-		
-		isCreatingCircuit = true;
-		try {
-			await invoke('new_identity');
-			console.log('New circuit requested successfully');
-		} catch (error) {
-			console.error('New circuit failed:', error);
-		} finally {
-			isCreatingCircuit = false;
-		}
-	}
+  async function handleDisconnect() {
+    await invoke("disconnect");
+  }
 
-	async function handleNewIdentity() {
-		if (isCreatingIdentity) return;
-		isCreatingIdentity = true;
-		try {
-			await invoke('new_identity');
-			console.log('New identity request sent successfully');
-		} catch (error) {
-			console.error('New identity failed:', error);
-		} finally {
-			isCreatingIdentity = false;
-		}
-	}
+  async function handleNewCircuit() {
+    if (!isConnected || isCreatingCircuit) return;
 
-        $: isConnected = $torStore.status === 'CONNECTED';
-        $: isStopped = $torStore.status === 'DISCONNECTED';
-       $: isConnecting = $torStore.status === 'CONNECTING' || $torStore.status === 'RETRYING';
-       $: isRetrying = $torStore.status === 'RETRYING';
-       $: isDisconnecting = $torStore.status === 'DISCONNECTING';
-       $: hasError = $torStore.status === 'ERROR';
+    isCreatingCircuit = true;
+    try {
+      await invoke("new_identity");
+      console.log("New circuit requested successfully");
+    } catch (error) {
+      console.error("New circuit failed:", error);
+    } finally {
+      isCreatingCircuit = false;
+    }
+  }
 
+  async function handleNewIdentity() {
+    if (isCreatingIdentity) return;
+    isCreatingIdentity = true;
+    try {
+      await invoke("new_identity");
+      console.log("New identity request sent successfully");
+    } catch (error) {
+      console.error("New identity failed:", error);
+    } finally {
+      isCreatingIdentity = false;
+    }
+  }
+
+  $: isConnected = $torStore.status === "CONNECTED";
+  $: isStopped = $torStore.status === "DISCONNECTED";
+  $: isConnecting =
+    $torStore.status === "CONNECTING" || $torStore.status === "RETRYING";
+  $: isRetrying = $torStore.status === "RETRYING";
+  $: isDisconnecting = $torStore.status === "DISCONNECTING";
+  $: hasError = $torStore.status === "ERROR";
 </script>
 
-<div class="glass-md rounded-xl p-6" tabindex="0" role="region" aria-label="Tor controls">
-	<!-- Error Message -->
-{#if $torStore.errorMessage}
-                <div class="mb-4 p-3 bg-red-900/30 border border-red-700/50 text-red-300 rounded-lg flex items-center gap-2" role="alert" aria-live="assertive">
-                        <AlertCircle size={16} />
-                        <span>
-                                {$torStore.errorMessage}
-                                {#if isRetrying}
-                                        (retry {$torStore.retryCount} in {$torStore.retryDelay}s)
-                                {/if}
-                        </span>
-                </div>
-{/if}
+<div
+  class="glass-md rounded-xl p-6"
+  tabindex="0"
+  role="region"
+  aria-label="Tor controls"
+>
+  <!-- Error Message -->
+  {#if $torStore.errorMessage}
+    <div
+      class="mb-4 p-3 bg-red-900/30 border border-red-700/50 text-red-300 rounded-lg flex items-center gap-2"
+      role="alert"
+      aria-live="assertive"
+    >
+      <AlertCircle size={16} />
+      <span>
+        {$torStore.errorMessage}
+        {#if $torStore.errorStep}
+          ({$torStore.errorStep}: {$torStore.errorSource})
+        {/if}
+        {#if isRetrying}
+          (retry {$torStore.retryCount} in {$torStore.retryDelay}s)
+        {/if}
+      </span>
+    </div>
+  {/if}
 
-	<!-- Four Buttons Layout -->
-	<div class="grid grid-cols-4 gap-3">
-               <!-- Connect/Disconnect Button -->
-               {#if isStopped || hasError}
-                       <button
-                               class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all duration-300 ease-in-out text-sm bg-green-600/20 text-green-200 hover:bg-green-600/30 border border-green-500/30 transform hover:scale-105"
-                               on:click={handleConnect}
-                               aria-label={hasError ? 'Retry connection' : 'Connect to Tor'}
-                       >
-                               <Play size={16} /> {hasError ? 'Retry' : 'Connect'}
-                       </button>
-		{:else if isConnecting}
-			<button
-                                class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 transition-all duration-300 ease-in-out text-sm bg-yellow-600/20 text-yellow-400 border border-yellow-500/30 opacity-75 cursor-not-allowed"
-				disabled={true}
-			>
-                                <div class="animate-spin"><RefreshCw size={16} /></div>
-                                {#if isRetrying}
-                                        Retrying in {$torStore.retryDelay}s (attempt {$torStore.retryCount})
-                                {:else}
-                                        Connecting...
-                                {/if}
-			</button>
-		{:else if isConnected}
-                        <button
-                                class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all duration-300 ease-in-out text-sm bg-red-600/20 text-red-200 hover:bg-red-600/30 border border-red-500/30 transform hover:scale-105"
-                                on:click={handleDisconnect}
-                                aria-label="Disconnect from Tor"
-                        >
-				<Square size={16} /> Disconnect
-			</button>
-		{:else if isDisconnecting}
-			<button
-                                class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 transition-all duration-300 ease-in-out text-sm bg-yellow-600/20 text-yellow-400 border border-yellow-500/30 opacity-75 cursor-not-allowed"
-				disabled={true}
-			>
-				<div class="animate-spin"><RefreshCw size={16} /></div>
-				Disconnecting...
-			</button>
-		{/if}
-		
-		<!-- New Circuit Button -->
-                <button
-                        class="glass-sm py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 transition-all duration-300 ease-in-out text-sm {isConnected && !isCreatingCircuit ? 'bg-black/50 text-white hover:bg-black/60 cursor-pointer transform hover:scale-105' : 'bg-black/30 text-gray-400 cursor-not-allowed opacity-50'}"
-                        on:click={handleNewCircuit}
-                        disabled={!isConnected || isCreatingCircuit}
-                        aria-label="Request new circuit"
-                >
-			{#if isCreatingCircuit}
-				<div class="animate-spin"><RefreshCw size={16} /></div>
-				Creating...
-			{:else}
-				<RotateCcw size={16} /> New Circuit
-			{/if}
-		</button>
-		
-		<!-- Logs Button -->
-                <button
-                        class="glass-sm py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all text-sm bg-black/50 text-white hover:bg-black/60"
-                        on:click={() => dispatch('openLogs')}
-                        aria-label="Open logs"
-                >
-			<Activity size={16} /> Logs
-		</button>
-		
-		<!-- Settings Button -->
-                <button
-                        class="glass-sm py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all text-sm bg-black/50 text-white hover:bg-black/60"
-                        on:click={() => dispatch('openSettings')}
-                        aria-label="Open settings"
-                >
-			<Settings size={16} /> Settings
-		</button>
-	</div>
+  <!-- Four Buttons Layout -->
+  <div class="grid grid-cols-4 gap-3">
+    <!-- Connect/Disconnect Button -->
+    {#if isStopped || hasError}
+      <button
+        class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all duration-300 ease-in-out text-sm bg-green-600/20 text-green-200 hover:bg-green-600/30 border border-green-500/30 transform hover:scale-105"
+        on:click={handleConnect}
+        aria-label={hasError ? "Retry connection" : "Connect to Tor"}
+      >
+        <Play size={16} />
+        {hasError ? "Retry" : "Connect"}
+      </button>
+    {:else if isConnecting}
+      <button
+        class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 transition-all duration-300 ease-in-out text-sm bg-yellow-600/20 text-yellow-400 border border-yellow-500/30 opacity-75 cursor-not-allowed"
+        disabled={true}
+      >
+        <div class="animate-spin"><RefreshCw size={16} /></div>
+        {#if isRetrying}
+          Retrying in {$torStore.retryDelay}s (attempt {$torStore.retryCount})
+        {:else}
+          Connecting...
+        {/if}
+      </button>
+    {:else if isConnected}
+      <button
+        class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all duration-300 ease-in-out text-sm bg-red-600/20 text-red-200 hover:bg-red-600/30 border border-red-500/30 transform hover:scale-105"
+        on:click={handleDisconnect}
+        aria-label="Disconnect from Tor"
+      >
+        <Square size={16} /> Disconnect
+      </button>
+    {:else if isDisconnecting}
+      <button
+        class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 transition-all duration-300 ease-in-out text-sm bg-yellow-600/20 text-yellow-400 border border-yellow-500/30 opacity-75 cursor-not-allowed"
+        disabled={true}
+      >
+        <div class="animate-spin"><RefreshCw size={16} /></div>
+        Disconnecting...
+      </button>
+    {/if}
+
+    <!-- New Circuit Button -->
+    <button
+      class="glass-sm py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 transition-all duration-300 ease-in-out text-sm {isConnected &&
+      !isCreatingCircuit
+        ? 'bg-black/50 text-white hover:bg-black/60 cursor-pointer transform hover:scale-105'
+        : 'bg-black/30 text-gray-400 cursor-not-allowed opacity-50'}"
+      on:click={handleNewCircuit}
+      disabled={!isConnected || isCreatingCircuit}
+      aria-label="Request new circuit"
+    >
+      {#if isCreatingCircuit}
+        <div class="animate-spin"><RefreshCw size={16} /></div>
+        Creating...
+      {:else}
+        <RotateCcw size={16} /> New Circuit
+      {/if}
+    </button>
+
+    <!-- Logs Button -->
+    <button
+      class="glass-sm py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all text-sm bg-black/50 text-white hover:bg-black/60"
+      on:click={() => dispatch("openLogs")}
+      aria-label="Open logs"
+    >
+      <Activity size={16} /> Logs
+    </button>
+
+    <!-- Settings Button -->
+    <button
+      class="glass-sm py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all text-sm bg-black/50 text-white hover:bg-black/60"
+      on:click={() => dispatch("openSettings")}
+      aria-label="Open settings"
+    >
+      <Settings size={16} /> Settings
+    </button>
+  </div>
 </div>

--- a/src/lib/components/IdlePanel.svelte
+++ b/src/lib/components/IdlePanel.svelte
@@ -1,66 +1,83 @@
 <script>
-export let connectionProgress = 0; // 0-100
-export let currentStatus = 'Idle'; // Current Tor status
-export let retryCount = 0;
-export let retryDelay = 0;
-export let bootstrapMessage = '';
+  export let connectionProgress = 0; // 0-100
+  export let currentStatus = "Idle"; // Current Tor status
+  export let retryCount = 0;
+  export let retryDelay = 0;
+  export let bootstrapMessage = "";
+  export let errorStep: string | null = null;
+  export let errorSource: string | null = null;
 
-const statusMap: Record<string, string> = {
-    DISCONNECTED: 'Disconnected',
-    CONNECTING: 'Connecting',
-    RETRYING: 'Retrying',
-    CONNECTED: 'Connected',
-    DISCONNECTING: 'Disconnecting',
-    ERROR: 'Error',
-};
+  const statusMap: Record<string, string> = {
+    DISCONNECTED: "Disconnected",
+    CONNECTING: "Connecting",
+    RETRYING: "Retrying",
+    CONNECTED: "Connected",
+    DISCONNECTING: "Disconnecting",
+    ERROR: "Error",
+  };
 
-$: statusText = statusMap[currentStatus] ?? currentStatus;
+  $: statusText = statusMap[currentStatus] ?? currentStatus;
 
-	// Animation for status text changes
-	let isAnimating = false;
-	let previousStatus = currentStatus;
+  // Animation for status text changes
+  let isAnimating = false;
+  let previousStatus = currentStatus;
 
-	$: if (currentStatus !== previousStatus) {
-		isAnimating = true;
-		setTimeout(() => {
-			previousStatus = currentStatus;
-			isAnimating = false;
-		}, 300);
-	}
+  $: if (currentStatus !== previousStatus) {
+    isAnimating = true;
+    setTimeout(() => {
+      previousStatus = currentStatus;
+      isAnimating = false;
+    }, 300);
+  }
 </script>
 
-<div class="glass-md rounded-xl p-6" tabindex="0" role="region" aria-label="Connection progress">
-	<div class="flex flex-col items-center gap-3">
-		<!-- Progress Bar -->
-                <div
-                        class="w-full bg-gray-700/50 rounded-full h-2"
-                        role="progressbar"
-                        aria-valuemin="0"
-                        aria-valuemax="100"
-                        aria-valuenow={connectionProgress}
-                >
-                        <div
-                                class="bg-white h-2 rounded-full transition-all duration-500 ease-out"
-                                style="width: {connectionProgress}%"
-                        ></div>
-                </div>
-                <p class="text-xs text-gray-100">{Math.round(connectionProgress)}%</p>
-                {#if bootstrapMessage}
-                        <p class="text-xs text-gray-100 italic">{bootstrapMessage}</p>
-                {/if}
-		
-		<!-- Animated Status Text -->
-                <div class="text-center relative h-4 flex items-center justify-center" aria-live="polite">
-                        <p
-                                class="text-xs font-medium text-white absolute transition-all duration-300 {isAnimating ? 'opacity-0 transform scale-95' : 'opacity-100 transform scale-100'}"
-                        >
-                                {statusText}
-                        </p>
-                </div>
-                {#if currentStatus === 'RETRYING'}
-                        <p class="text-xs text-yellow-300">retry {retryCount} in {retryDelay}s</p>
-                {:else if currentStatus === 'ERROR'}
-                        <p class="text-xs text-red-300">connection failed</p>
-                {/if}
-        </div>
+<div
+  class="glass-md rounded-xl p-6"
+  tabindex="0"
+  role="region"
+  aria-label="Connection progress"
+>
+  <div class="flex flex-col items-center gap-3">
+    <!-- Progress Bar -->
+    <div
+      class="w-full bg-gray-700/50 rounded-full h-2"
+      role="progressbar"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-valuenow={connectionProgress}
+    >
+      <div
+        class="bg-white h-2 rounded-full transition-all duration-500 ease-out"
+        style="width: {connectionProgress}%"
+      ></div>
+    </div>
+    <p class="text-xs text-gray-100">{Math.round(connectionProgress)}%</p>
+    {#if bootstrapMessage}
+      <p class="text-xs text-gray-100 italic">{bootstrapMessage}</p>
+    {/if}
+
+    <!-- Animated Status Text -->
+    <div
+      class="text-center relative h-4 flex items-center justify-center"
+      aria-live="polite"
+    >
+      <p
+        class="text-xs font-medium text-white absolute transition-all duration-300 {isAnimating
+          ? 'opacity-0 transform scale-95'
+          : 'opacity-100 transform scale-100'}"
+      >
+        {statusText}
+      </p>
+    </div>
+    {#if currentStatus === "RETRYING"}
+      <p class="text-xs text-yellow-300">retry {retryCount} in {retryDelay}s</p>
+    {:else if currentStatus === "ERROR"}
+      <p class="text-xs text-red-300">
+        connection failed
+        {#if errorStep}
+          - {errorStep}: {errorSource}
+        {/if}
+      </p>
+    {/if}
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- propagate circuit list errors via `report_error`
- surface close circuit errors
- include list_circuit errors in metrics
- display error step/source in ActionCard and IdlePanel
- test new_identity error reporting in command layer
- test UI error display

## Testing
- `npm test` *(fails: TestingLibraryElementError, NotFoundError)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686cc5c0b2688333a8c992e57d056ecd