### PR TITLE
Enhance network metrics docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Torwell84 is a privacy-focused Tor client built with modern technologies to prov
 - **Modern Stack**: Svelte-based frontend with TypeScript
 - **Structured Logging**: JSON log entries with level and timestamp
 - **Resource Monitoring**: Tray warnings for memory usage, circuit count and latency
+- **Network Metrics**: `NetworkMonitor` and `NetworkTools` visualise CPU usage, traffic and traceroute results obtained from the backend
 - **HSM Support**: Optional PKCS#11 integration when built with the `hsm` feature
 - **Mobile Workflow**: Capacitor-based build with HTTP bridge
 - **Circuit Metrics**: Uses arti's experimental APIs when built with the
@@ -357,7 +358,7 @@ The backend emits structured `Error` variants via the `tor-status-update` event.
 - [x] Windows support
 - [x] Advanced circuit management
 - [x] Live resource monitoring with tray warnings
-- [ ] Network monitoring tools
+- [x] Network monitoring tools
 
 ## 🤝 Contributing
 

--- a/docs/GlassUI.md
+++ b/docs/GlassUI.md
@@ -30,3 +30,7 @@ Farbwahl und Kontrast müssen dabei den WCAG&nbsp;2.1 AA Richtlinien entsprechen
 * Die Tab-Reihenfolge folgt der visuellen Darstellung.
 * In Modalen landet der Fokus zunächst auf dem Schließen‑Button und wird anschließend innerhalb des Dialogs gehalten (Fokusfalle).
 * Alle Bedienelemente müssen per Tastatur erreichbar sein und aussagekräftige `aria-label` Attribute besitzen.
+
+## Netzwerk-Metriken
+
+`NetworkMonitor.svelte` und `NetworkTools.svelte` visualisieren die im Backend ermittelten Nutzungsdaten. CPU- und Netzwerkverbrauch werden über das Kommando `load_metrics` geladen. Für Host-Informationen nutzen die Tools die Befehle `dns_lookup` und `traceroute_host`. Die gemessenen Werte werden direkt in der Oberfläche dargestellt.

--- a/src/__tests__/NetworkMonitor.spec.ts
+++ b/src/__tests__/NetworkMonitor.spec.ts
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { vi } from 'vitest';
+
+let metricsCallback: (e: any) => void = () => {};
+var invoke: any;
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (ev: string, cb: any) => {
+    if (ev === 'metrics-update') metricsCallback = cb;
+    return () => {};
+  })
+}));
+vi.mock('@tauri-apps/api/tauri', () => {
+  invoke = vi.fn(async (cmd: string) => {
+    if (cmd === 'request_token') return 42;
+    if (cmd === 'load_metrics') return [{
+      time: 0,
+      memoryMB: 0,
+      circuitCount: 0,
+      latencyMs: 0,
+      oldestAge: 0,
+      avgCreateMs: 0,
+      failedAttempts: 0,
+      cpuPercent: 1,
+      networkBytes: 0,
+      networkTotal: 100,
+      complete: true
+    }];
+  });
+  return { invoke };
+});
+
+import NetworkMonitor from '../lib/components/NetworkMonitor.svelte';
+
+describe('NetworkMonitor', () => {
+  it('loads metrics and updates on events', async () => {
+    const { getByText } = render(NetworkMonitor);
+    await tick();
+    await tick();
+    expect(invoke).toHaveBeenNthCalledWith(2, 'load_metrics', { token: 42 });
+
+    metricsCallback({
+      payload: {
+        memory_bytes: 0,
+        circuit_count: 0,
+        latency_ms: 0,
+        oldest_age: 0,
+        avg_create_ms: 0,
+        failed_attempts: 0,
+        cpu_percent: 2.5,
+        network_bytes: 0,
+        total_network_bytes: 200,
+        complete: true
+      }
+    });
+    await tick();
+    expect(getByText(/CPU: 2.5 %/)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/NetworkTools.spec.ts
+++ b/src/__tests__/NetworkTools.spec.ts
@@ -1,11 +1,21 @@
 import { render, fireEvent } from '@testing-library/svelte';
 import { vi } from 'vitest';
 
-vi.mock('@tauri-apps/api/tauri', () => ({ invoke: vi.fn(async () => 42) }));
+var rawInvoke: any;
+vi.mock('@tauri-apps/api/tauri', () => {
+  rawInvoke = vi.fn(async (cmd: string) => {
+    if (cmd === 'request_token') return 42;
+    if (cmd === 'dns_lookup') return ['1.1.1.1'];
+    if (cmd === 'traceroute_host') return ['1.1.1.1', '2.2.2.2'];
+    if (cmd === 'lookup_country') return 'US';
+    return [];
+  });
+  return { invoke: rawInvoke };
+});
 global.fetch = vi.fn(async () => ({ ok: true, text: async () => 'US' })) as any;
 
 import NetworkTools from '../lib/components/NetworkTools.svelte';
-import { invoke } from '@tauri-apps/api/tauri';
+import { invoke as tauriInvoke } from '@tauri-apps/api/tauri';
 
 describe('NetworkTools', () => {
   it('calls dns_lookup on button click', async () => {
@@ -13,12 +23,23 @@ describe('NetworkTools', () => {
     const input = getByLabelText('Host') as HTMLInputElement;
     await fireEvent.input(input, { target: { value: 'example.com' } });
     await fireEvent.click(getByText('DNS Lookup'));
-    expect(invoke).toHaveBeenNthCalledWith(2, 'dns_lookup', { token: 42, host: 'example.com' });
+    expect(tauriInvoke).toHaveBeenNthCalledWith(2, 'dns_lookup', { token: 42, host: 'example.com' });
+  });
+
+  it('copies dns results', async () => {
+    (navigator as any).clipboard = { writeText: vi.fn() };
+    const { getByRole, getByLabelText, findByRole } = render(NetworkTools);
+    const input = getByLabelText('Host') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'example.com' } });
+    await fireEvent.click(getByRole('button', { name: 'DNS Lookup' }));
+    const copyBtn = await findByRole('button', { name: 'Copy DNS results' });
+    await fireEvent.click(copyBtn);
+    expect((navigator as any).clipboard.writeText).toHaveBeenCalledWith('1.1.1.1');
   });
 
   it('shows traceroute output', async () => {
-    (invoke as any).mockReset();
-    (invoke as any)
+    (tauriInvoke as any).mockReset();
+    (tauriInvoke as any)
       .mockResolvedValueOnce(42)
       .mockResolvedValueOnce(['hop1', 'hop2']);
 
@@ -28,6 +49,21 @@ describe('NetworkTools', () => {
     await fireEvent.click(getByText('Traceroute'));
 
     await findByText('hop2');
-    expect(invoke).toHaveBeenNthCalledWith(2, 'traceroute_host', { token: 42, host: 'example.com', maxHops: 8 });
+    expect(tauriInvoke).toHaveBeenNthCalledWith(2, 'traceroute_host', { token: 42, host: 'example.com', maxHops: 8 });
+  });
+
+  it('copies traceroute results', async () => {
+    (tauriInvoke as any).mockReset();
+    (tauriInvoke as any)
+      .mockResolvedValueOnce(42)
+      .mockResolvedValueOnce(['1.1.1.1', '2.2.2.2']);
+    (navigator as any).clipboard = { writeText: vi.fn() };
+    const { getByRole, getByLabelText, findByRole } = render(NetworkTools);
+    const input = getByLabelText('Host') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'example.com' } });
+    await fireEvent.click(getByRole('button', { name: 'Traceroute' }));
+    const copyBtn = await findByRole('button', { name: 'Copy traceroute results' });
+    await fireEvent.click(copyBtn);
+    expect((navigator as any).clipboard.writeText).toHaveBeenCalledWith('1. 1.1.1.1\n2. 2.2.2.2');
   });
 });

--- a/src/lib/components/NetworkTools.svelte
+++ b/src/lib/components/NetworkTools.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke, lookupCountry } from "$lib/api";
+  import { invoke } from "$lib/api";
   import { addToast, addErrorToast } from "$lib/stores/toastStore";
   let host = "";
   let dns: string[] = [];
@@ -7,7 +7,7 @@
   let countries: string[] = [];
   let loading = false;
 
-  async function lookupCountry(ip: string): Promise<string> {
+  async function lookupCountryLocal(ip: string): Promise<string> {
     try {
       const res = (await invoke("lookup_country", { ip })) as string;
       return res.trim() || "??";
@@ -46,7 +46,7 @@
     loading = true;
     try {
       route = (await invoke("traceroute_host", { host, maxHops: 8 })) as string[];
-      countries = await Promise.all(route.map((ip) => lookupCountry(ip)));
+      countries = await Promise.all(route.map((ip) => lookupCountryLocal(ip)));
     } catch (e: any) {
       route = [];
       countries = [];
@@ -59,17 +59,17 @@
 
 <div class="glass-md rounded-xl p-4 flex flex-col gap-2" aria-label="Network tools">
   <div>
-    <label class="text-sm text-white">Host</label>
-    <input class="ml-2 p-1 rounded text-black" bind:value={host} />
+    <label class="text-sm text-white" for="host-input">Host</label>
+    <input id="host-input" aria-label="Host" class="ml-2 p-1 rounded text-black" bind:value={host} />
   </div>
   <div class="flex gap-2">
-    <button class="glass px-2 py-1 rounded" on:click|preventDefault={lookup} disabled={loading}>DNS Lookup</button>
-    <button class="glass px-2 py-1 rounded" on:click|preventDefault={trace} disabled={loading}>Traceroute</button>
+    <button aria-label="DNS Lookup" class="glass px-2 py-1 rounded" on:click|preventDefault={lookup} disabled={loading}>DNS Lookup</button>
+    <button aria-label="Traceroute" class="glass px-2 py-1 rounded" on:click|preventDefault={trace} disabled={loading}>Traceroute</button>
   </div>
   {#if dns.length}
     <div class="flex items-center justify-between">
       <h3 class="text-sm text-white">DNS Results</h3>
-      <button class="glass px-1 rounded text-xs" on:click={copyDns}>Copy</button>
+      <button aria-label="Copy DNS results" class="glass px-1 rounded text-xs" on:click={copyDns}>Copy</button>
     </div>
     <table class="text-xs text-white w-full" aria-label="DNS results">
       <thead>
@@ -86,7 +86,7 @@
   {#if route.length}
     <div class="flex items-center justify-between mt-2">
       <h3 class="text-sm text-white">Traceroute</h3>
-      <button class="glass px-1 rounded text-xs" on:click={copyRoute}>Copy</button>
+      <button aria-label="Copy traceroute results" class="glass px-1 rounded text-xs" on:click={copyRoute}>Copy</button>
     </div>
     <table class="text-xs text-white w-full" aria-label="Traceroute results">
       <thead>


### PR DESCRIPTION
## Summary
- improve ARIA labels in `NetworkTools.svelte`
- document network metric usage
- add unit tests for NetworkTools and NetworkMonitor

## Testing
- `npx vitest run src/__tests__/NetworkTools.spec.ts src/__tests__/NetworkMonitor.spec.ts` *(fails: spy call to load_metrics, element not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc89c3efc8333aac8397c315f30fd