### PR TITLE
Ensure metrics docs and improve tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Torwell84 is a privacy-focused Tor client built with modern technologies to prov
 - **Modern Stack**: Svelte-based frontend with TypeScript
 - **Structured Logging**: JSON log entries with level and timestamp
 - **Resource Monitoring**: Tray warnings for memory usage, circuit count and latency
-- **Network Metrics**: `NetworkMonitor` and `NetworkTools` visualise CPU usage, traffic and traceroute results obtained from the backend
+ - **Network Metrics**: `NetworkMonitor` and `NetworkTools` visualise CPU usage, traffic and traceroute results obtained from the backend.
+   These widgets rely entirely on the metrics measured by the Rust backend.
 - **HSM Support**: Optional PKCS#11 integration when built with the `hsm` feature
 - **Mobile Workflow**: Capacitor-based build with HTTP bridge
 - **Circuit Metrics**: Uses arti's experimental APIs when built with the

--- a/docs/GlassUI.md
+++ b/docs/GlassUI.md
@@ -34,3 +34,4 @@ Farbwahl und Kontrast müssen dabei den WCAG&nbsp;2.1 AA Richtlinien entsprechen
 ## Netzwerk-Metriken
 
 `NetworkMonitor.svelte` und `NetworkTools.svelte` visualisieren die im Backend ermittelten Nutzungsdaten. CPU- und Netzwerkverbrauch werden über das Kommando `load_metrics` geladen. Für Host-Informationen nutzen die Tools die Befehle `dns_lookup` und `traceroute_host`. Die gemessenen Werte werden direkt in der Oberfläche dargestellt.
+Ohne laufenden Backend-Prozess stehen keine Metriken zur Verfügung.

--- a/src/__tests__/NetworkTools.spec.ts
+++ b/src/__tests__/NetworkTools.spec.ts
@@ -41,7 +41,8 @@ describe('NetworkTools', () => {
     (tauriInvoke as any).mockReset();
     (tauriInvoke as any)
       .mockResolvedValueOnce(42)
-      .mockResolvedValueOnce(['hop1', 'hop2']);
+      .mockResolvedValueOnce(['hop1', 'hop2'])
+      .mockResolvedValue('US');
 
     const { getByText, getByLabelText, findByText } = render(NetworkTools);
     const input = getByLabelText('Host') as HTMLInputElement;
@@ -50,6 +51,8 @@ describe('NetworkTools', () => {
 
     await findByText('hop2');
     expect(tauriInvoke).toHaveBeenNthCalledWith(2, 'traceroute_host', { token: 42, host: 'example.com', maxHops: 8 });
+    expect(tauriInvoke).toHaveBeenNthCalledWith(3, 'lookup_country', { ip: 'hop1' });
+    expect(tauriInvoke).toHaveBeenNthCalledWith(4, 'lookup_country', { ip: 'hop2' });
   });
 
   it('copies traceroute results', async () => {

--- a/src/lib/components/NetworkTools.svelte
+++ b/src/lib/components/NetworkTools.svelte
@@ -57,7 +57,7 @@
   }
 </script>
 
-<div class="glass-md rounded-xl p-4 flex flex-col gap-2" aria-label="Network tools">
+<div class="glass-md rounded-xl p-4 flex flex-col gap-2" role="region" aria-label="Network tools">
   <div>
     <label class="text-sm text-white" for="host-input">Host</label>
     <input id="host-input" aria-label="Host" class="ml-2 p-1 rounded text-black" bind:value={host} />


### PR DESCRIPTION
## Summary
- document that NetworkMonitor and NetworkTools rely on metrics from backend
- clarify this in GlassUI docs
- mark NetworkTools component as region for a11y
- expand tests to check lookup_country calls

## Testing
- `bun run vitest run src/__tests__/NetworkTools.spec.ts src/__tests__/NetworkMonitor.spec.ts` *(fails: Could not find element and spy expectations)*

------
https://chatgpt.com/codex/tasks/task_e_686ccb6efa348333acb4bd7f78fa9fd5