### PR TITLE
Update metrics docs and placeholders

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -2,10 +2,9 @@
 
 ## Circuit Metrics
 
-`TorManager::circuit_metrics` relies on the optional `experimental-api` feature
-of `arti-client` to query currently open circuits. When this feature is disabled
-the library now estimates the number of circuits based on existing isolation
-tokens. Other metrics such as build time remain unknown in this mode and are
-reported as `null` to the frontend. Enable the flag with `--features
-experimental-api` (or use `task build`, which sets it by default) for fully
-accurate metrics.
+`TorManager::circuit_metrics` is implemented and relies on the optional
+`experimental-api` feature of `arti-client` to query currently open circuits.
+Without this feature only an approximation of the circuit count is possible and
+metrics like build time remain unknown. They are reported as `null` to the
+frontend. Enable the flag with `--features experimental-api` (or use
+`task build`, which sets it by default) for fully accurate metrics.

--- a/docs/ProductionCertificate.md
+++ b/docs/ProductionCertificate.md
@@ -9,7 +9,7 @@ Create a PEM encoded certificate with your internal or public CA. For quick test
 ```bash
 openssl req -new -newkey rsa:4096 -days 90 -nodes -x509 \
     -keyout server.key -out server.pem \
-    -subj "/CN=certs.torwell.com"
+    -subj "/CN=certs.yourdomain.example"
 ```
 
 Place `server.pem` on your update server. Renew the file every 90 days.
@@ -73,7 +73,7 @@ Running this job ensures that clients can fetch the new certificate during the n
 Instead of editing the configuration file you can override the values at runtime:
 
 ```bash
-export TORWELL_CERT_URL=https://updates.torwell.com/certs/server.pem
+export TORWELL_CERT_URL=https://updates.yourdomain.example/certs/server.pem
 export TORWELL_CERT_PATH=/etc/torwell/server.pem
 export TORWELL_FALLBACK_CERT_URL=https://backup.example.com/server.pem
 ```
@@ -88,7 +88,7 @@ Automate certificate updates with a small script that copies the new PEM to the 
 #!/bin/bash
 set -e
 scp /pki/torwell/server.pem \
-    user@certs.torwell.com:/var/www/certs/server.pem
+    user@certs.yourdomain.example:/var/www/certs/server.pem
 ```
 
 Running this script after each renewal ensures that clients download the new certificate during the next update check.

--- a/docs/TODO123.md
+++ b/docs/TODO123.md
@@ -9,4 +9,4 @@
 - None
 
 ## Limitations
-- Circuit metrics (active circuit count and age) will be added when arti-client provides a circuit listing API.
+- Circuit metrics (active circuit count and age) are now implemented using the circuit listing API in arti-client.

--- a/docs/examples/cert_config.json
+++ b/docs/examples/cert_config.json
@@ -2,7 +2,7 @@
   "cert_path": "/etc/torwell/server.pem",
   "cert_path_windows": "%APPDATA%\\Torwell84\\server.pem",
   "cert_path_macos": "/Library/Application Support/Torwell84/server.pem",
-  "cert_url": "https://updates.example.com/certs/server.pem",
+  "cert_url": "https://updates.yourdomain.example/certs/server.pem",
   "fallback_cert_url": null,
   "min_tls_version": "1.2",
   "update_interval": 86400,


### PR DESCRIPTION
## Summary
- clarify circuit metrics are implemented
- explain limited metrics without `experimental-api`
- use placeholder URLs in ProductionCertificate docs and example config

## Testing
- `bun test` *(fails: Cannot find module '@testing-library/svelte')*

------
https://chatgpt.com/codex/tasks/task_e_686cd8693e9883338c3c6dcc24f7c251