### PR TITLE
Align CF worker docs and fix proxy example

### DIFF
--- a/cf worker/README.md
+++ b/cf worker/README.md
@@ -27,4 +27,4 @@ Dieses Verzeichnis enthält Beispielskripte für einen HTTPS‑Proxy als Cloudfl
 Nach dem Deployment kann die URL des Workers in Torwell84 unter **Settings → Worker List** eingetragen und das Token hinterlegt werden. Optional lässt sich die Adresse in `src/lib/bridge_presets.json` vorbelegen.
 Torwell84 validiert den eingetragenen Token sofort mittels `validate_worker_token`. Erst nach erfolgreichem Test wird die Konfiguration aktiv.
 
-Mehrere Worker lassen sich komfortabel mit dem Skript `scripts/import_workers.ts` importieren.
+Mehrere Worker lassen sich komfortabel mit dem Skript `scripts/import_workers.ts` importieren. Alternativ steht das CLI-Skript `scripts/import_workers_cli.ts` bereit.

--- a/cf worker/Super-HTTPS-Proxy-CF-Worker-.txt
+++ b/cf worker/Super-HTTPS-Proxy-CF-Worker-.txt
@@ -11,6 +11,7 @@ export default {
     if (!target) {
       return new Response('Missing ?url parameter', { status: 400 });
     }
-    return fetch(target, request);
+    const proxyRequest = new Request(target, request);
+    return fetch(proxyRequest);
   }
 };

--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -22,6 +22,8 @@ Dieses Dokument beschreibt, wie du den Beispiel‑Worker aus dem Ordner `cf work
    wrangler deploy
    ```
    Der Worker prüft bei jeder Anfrage, ob der Header `X-Proxy-Token` dem gesetzten `SECRET_TOKEN` entspricht.
+   Die Zieladresse wird im Query-Parameter `url` 
+   übergeben, z.B. `https://<worker-url>/?url=https://example.com`.
 
 ## Proxy in Torwell84 einrichten
 


### PR DESCRIPTION
## Summary
- document CF worker deployment consistently in docs/Todo-fuer-User.md and cf worker/README.md
- mention CLI import script in worker README
- fix example code in `Super-HTTPS-Proxy-CF-Worker-.txt` to correctly clone the incoming request

## Testing
- `bun test` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d452eda488333bc5ac12d08e80586