### PR TITLE
Fix type check errors

### DIFF
--- a/src/__tests__/ErrorBoundary.spec.ts
+++ b/src/__tests__/ErrorBoundary.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/svelte';
 import { describe, it, expect } from 'vitest';
-import { errorStore } from '../lib/components/AppErrorBoundary.svelte';
+import { errorStore } from '../lib/stores/errorStore';
 import Wrapper from './ErrorBoundaryWrapper.svelte';
 
 describe('AppErrorBoundary', () => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { invoke as tauriInvoke } from '@tauri-apps/api/tauri';
-import { errorStore } from '$lib/components/AppErrorBoundary.svelte';
+import { errorStore } from '$lib/stores/errorStore';
 
 let token: string | null = null;
 

--- a/src/lib/components/AppErrorBoundary.svelte
+++ b/src/lib/components/AppErrorBoundary.svelte
@@ -1,10 +1,6 @@
-<script context="module" lang="ts">
-import { writable } from 'svelte/store';
-export const errorStore = writable<Error | null>(null);
-</script>
-
 <script lang="ts">
 import ErrorBoundary from 'svelte-error-boundary';
+import { errorStore } from '$lib/stores/errorStore';
 
 function handleError(err: Error) {
   errorStore.set(err);

--- a/src/lib/components/CircuitManager.svelte
+++ b/src/lib/components/CircuitManager.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { invoke } from '$lib/api';
+  export let className = '';
   let circuits: number[] = [];
 
   async function refresh() {
@@ -24,7 +25,7 @@
   onMount(refresh);
 </script>
 
-<div class="glass-md rounded-xl p-4" aria-label="Circuits">
+<div class={"glass-md rounded-xl p-4 " + className} aria-label="Circuits">
   <h3 class="text-base font-medium text-white mb-2">Circuits</h3>
   <ul class="space-y-1">
     {#each circuits as id}

--- a/src/lib/components/ErrorOverlay.svelte
+++ b/src/lib/components/ErrorOverlay.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-import { errorStore } from './AppErrorBoundary.svelte';
+import { errorStore } from '$lib/stores/errorStore';
 import { onDestroy } from 'svelte';
 
 let error: Error | null = null;
-const unsub = errorStore.subscribe((e) => (error = e));
+const unsub = errorStore.subscribe((e: Error | null) => (error = e));
 onDestroy(unsub);
 </script>
 

--- a/src/lib/components/NetworkMonitor.svelte
+++ b/src/lib/components/NetworkMonitor.svelte
@@ -3,6 +3,7 @@
   import { listen } from '@tauri-apps/api/event';
   import { invoke } from '@tauri-apps/api/tauri';
   import type { MetricPoint } from '$lib/stores/torStore';
+  export let className = '';
 
   let metrics: MetricPoint[] = [];
   const MAX_POINTS = 30;
@@ -76,7 +77,7 @@
   });
 </script>
 
-<div class="glass-md rounded-xl p-4 space-y-4" role="region" aria-label="Network monitor">
+<div class={"glass-md rounded-xl p-4 space-y-4 " + className} role="region" aria-label="Network monitor">
   <div class="flex gap-4">
     <div class="flex-1">
       <p class="text-sm text-white">CPU: {latest.cpuPercent.toFixed(1)} %</p>

--- a/src/lib/stores/errorStore.ts
+++ b/src/lib/stores/errorStore.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const errorStore = writable<Error | null>(null);

--- a/src/routes/circuits/+page.svelte
+++ b/src/routes/circuits/+page.svelte
@@ -1,9 +1,9 @@
-<script>
+<script lang="ts">
   import CircuitManager from '$lib/components/CircuitManager.svelte';
   export const ssr = false;
 </script>
 
 <div class="p-6 max-w-6xl mx-auto">
-  <a href="/" class="text-blue-400 underline">Back</a>
-  <CircuitManager class="mt-4" />
+  <a href={'/'} class="text-blue-400 underline">Back</a>
+  <CircuitManager className="mt-4" />
 </div>

--- a/src/routes/network/+page.svelte
+++ b/src/routes/network/+page.svelte
@@ -1,9 +1,9 @@
-<script>
+<script lang="ts">
   import NetworkMonitor from '$lib/components/NetworkMonitor.svelte';
   export const ssr = false;
 </script>
 
 <div class="p-6 max-w-6xl mx-auto">
-  <a href="/" class="text-blue-400 underline">Back</a>
-  <NetworkMonitor class="mt-4" />
+  <a href={'/'} class="text-blue-400 underline">Back</a>
+  <NetworkMonitor className="mt-4" />
 </div>


### PR DESCRIPTION
## Summary
- make `errorStore` a normal TS store module
- update components to use the new store
- allow `CircuitManager` and `NetworkMonitor` to accept a `className`
- use `className` prop in network and circuits pages

## Testing
- `bun run check`


------
https://chatgpt.com/codex/tasks/task_e_686d452d529c833397b199ea43dc8266