### PR TITLE
Add desktop build workflow

### DIFF
--- a/.github/workflows/builddesktop.yml
+++ b/.github/workflows/builddesktop.yml
@@ -1,0 +1,51 @@
+name: BuildDesktop
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install WiX Toolset
+        if: matrix.os == 'windows-latest'
+        run: choco install wixtoolset -y
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libssl-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run tauri build --features experimental-api
+      - name: Sign MSI
+        if: matrix.os == 'windows-latest'
+        env:
+          WINDOWS_CERT: ${{ secrets.WINDOWS_CERT }}
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        run: |
+          if ($env:WINDOWS_CERT -and $env:WINDOWS_CERT_PASSWORD) {
+            $certPath = "$env:RUNNER_TEMP\\cert.pfx"
+            [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String($env:WINDOWS_CERT))
+            signtool sign /f $certPath /p $env:WINDOWS_CERT_PASSWORD \
+              /tr http://timestamp.digicert.com /td sha256 /fd sha256 \
+              src-tauri/target/release/bundle/msi/*.msi
+          }
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-bundle
+          path: src-tauri/target/release/bundle


### PR DESCRIPTION
## Summary
- add `builddesktop.yml` GitHub Actions workflow for building desktop bundles across Linux, Windows and macOS

## Testing
- `bun install`
- `bun test` *(fails: vi.mock is not a function and document not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686d7432cab083338e1af2b5872699a1