### PR TITLE
Update mobile build scripts and docs

### DIFF
--- a/docs/Mobile.md
+++ b/docs/Mobile.md
@@ -93,3 +93,28 @@ prüfen, ob die APK- bzw. IPA-Datei korrekt erstellt wurde.
 - **iOS:** Öffne `mobile/ios/App.xcworkspace` in Xcode und wähle einen
   Simulator aus. Du kannst das erzeugte `.ipa` aus `mobile/dist` auch über das
   Geräte-Fenster von Xcode auf ein verbundenes Gerät ziehen.
+
+## Installation & Debugging
+
+### Android
+
+1. Stelle sicher, dass die Android-SDK-Plattform \(API 34\) installiert ist.
+2. Installiere das APK auf einem Gerät oder Emulator und verfolge die Logs:
+
+   ```bash
+   adb install -r mobile/dist/*.apk
+   adb logcat
+   ```
+
+### iOS
+
+1. Öffne das Projekt mit Xcode:
+
+   ```bash
+   npx cap open ios
+   ```
+
+2. Wähle einen Simulator oder ein angeschlossenes Gerät und starte die App. Die
+   Xcode-Konsole zeigt die Debug-Ausgabe an. Alternativ kannst du die `.ipa`
+   mittels `xcrun simctl install booted mobile/dist/*.ipa` auf einen Simulator
+   kopieren.

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,11 +8,11 @@
     "ios": "npx cap run ios"
   },
   "dependencies": {
-    "@capacitor/core": "^5.0.0"
+    "@capacitor/core": "^7.4.1"
   },
   "devDependencies": {
-    "@capacitor/cli": "^5.0.0",
-    "@capacitor/android": "^5.0.0",
-    "@capacitor/ios": "^5.0.0"
+    "@capacitor/cli": "^7.4.1",
+    "@capacitor/android": "^7.4.1",
+    "@capacitor/ios": "^7.4.1"
   }
 }

--- a/mobile/scripts/test_artifacts.sh
+++ b/mobile/scripts/test_artifacts.sh
@@ -10,6 +10,17 @@ status=0
 if [ "$TYPE" != "ios" ]; then
   if [ -n "$APK" ]; then
     echo "Found APK: $APK"
+    if unzip -t "$APK" >/dev/null; then
+      if unzip -l "$APK" | grep -q "AndroidManifest.xml"; then
+        echo "APK archive looks valid"
+      else
+        echo "AndroidManifest.xml missing in APK" >&2
+        status=1
+      fi
+    else
+      echo "APK archive appears corrupted" >&2
+      status=1
+    fi
   else
     echo "APK not found in mobile/android" >&2
     status=1
@@ -19,6 +30,17 @@ fi
 if [ "$TYPE" != "android" ]; then
   if [ -n "$IPA" ]; then
     echo "Found IPA: $IPA"
+    if unzip -t "$IPA" >/dev/null; then
+      if unzip -l "$IPA" | grep -q "Payload/"; then
+        echo "IPA archive looks valid"
+      else
+        echo "Payload folder missing in IPA" >&2
+        status=1
+      fi
+    else
+      echo "IPA archive appears corrupted" >&2
+      status=1
+    fi
   else
     echo "IPA not found in mobile/ios" >&2
     status=1


### PR DESCRIPTION
## Summary
- bump Capacitor packages to v7
- enforce SDK versions in mobile build scripts
- sync before building and verify artifacts
- document install & debug steps for mobile apps

## Testing
- `bun test` *(fails: Cannot find module '@testing-library/svelte')*

------
https://chatgpt.com/codex/tasks/task_e_686d7a0a2d8883339f108c2f96ec7ffd