### PR TITLE
Update service scripts and docs

### DIFF
--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -40,7 +40,9 @@ Running the script prints the commands that would be executed and a brief
 status report:
 
 ```text
-Installing service file to /tmp/tmp.XYZ
+Installing Torwell84 systemd service...
+Copying service file to /tmp/tmp.XYZ
+Service file installed
 systemctl daemon-reload
 Enabling and starting torwell84.service
 systemctl enable --now torwell84.service
@@ -48,6 +50,7 @@ Service status:
 \u25cf torwell84.service - Fake Service
    Loaded: loaded (/tmp/tmp.XYZ/torwell84.service; enabled)
    Active: active (running)
+Installation complete.
 Service file installed in /tmp/tmp.XYZ
 Test completed successfully
 ```

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -8,6 +8,8 @@
 # resulting bundles to `src-tauri/target/release/bundle`.
 set -e
 
+echo "Building release bundles..."
+
 check_dep() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "Error: '$1' is required but not installed." >&2

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+echo "Installing Torwell84 systemd service..."
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SERVICE_FILE="$ROOT_DIR/src-tauri/torwell84.service"
 TARGET_DIR="${TARGET_DIR:-/etc/systemd/system}"
@@ -33,8 +35,9 @@ fi
 $SUDO mkdir -p /opt/torwell84
 
 # Copy service file to systemd directory
-echo "Installing service file to $TARGET_DIR"
+echo "Copying service file to $TARGET_DIR"
 $SUDO cp "$SERVICE_FILE" "$TARGET_DIR/"
+echo "Service file installed"
 
 # Reload systemd manager configuration
 $SUDO $SYSTEMCTL daemon-reload
@@ -45,4 +48,5 @@ $SUDO $SYSTEMCTL enable --now torwell84.service
 
 echo "Service status:"
 $SUDO $SYSTEMCTL --no-pager status torwell84.service
+echo "Installation complete."
 

--- a/scripts/test_service_install.sh
+++ b/scripts/test_service_install.sh
@@ -2,6 +2,7 @@
 set -e
 
 TMP_DIR=$(mktemp -d)
+echo "Testing service installation in temporary directory $TMP_DIR"
 FAKE_SYSTEMCTL="$TMP_DIR/systemctl"
 
 cat > "$FAKE_SYSTEMCTL" <<'SCRIPT'

--- a/src-tauri/certs/cert_config.json
+++ b/src-tauri/certs/cert_config.json
@@ -6,5 +6,4 @@
   "fallback_cert_url": null,
   "min_tls_version": "1.2",
   "update_interval": 86400,
-  "note": "Production certificate update endpoint"
-}
+  "note": "Production certificate update endpoint"}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -66,5 +66,4 @@
         "${TAURI_UPDATE_URL}"
       ]
     }
-  }
-}
+  }}


### PR DESCRIPTION
## Summary
- print progress while building release bundles
- clarify installation output for torwell84 service
- note new messages in service install test output
- sync ProductionDeployment instructions with script updates
- fix missing EOF newlines in cert and Tauri config files

## Testing
- `bun run check` *(fails: svelte-kit not found)*
- `cargo test` *(fails: glib-2.0 development libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d7a08ff508333acc0a24322a16a93