### PR TITLE
Improve worker import scripts and tests

### DIFF
--- a/docs/Todo-fuer-User.md
+++ b/docs/Todo-fuer-User.md
@@ -22,7 +22,7 @@ Dieses Dokument beschreibt, wie du den Beispiel‑Worker aus dem Ordner `cf work
    wrangler deploy
    ```
    Der Worker prüft bei jeder Anfrage, ob der Header `X-Proxy-Token` dem gesetzten `SECRET_TOKEN` entspricht.
-   Die Zieladresse wird im Query-Parameter `url` 
+   Die Zieladresse wird im Query-Parameter `url`
    übergeben, z.B. `https://<worker-url>/?url=https://example.com`.
 
 ## Proxy in Torwell84 einrichten
@@ -72,3 +72,25 @@ Damit lassen sich hunderte URLs bequem importieren.
 Unter **Settings → HSM Configuration** kannst du den Pfad zur PKCS#11‑Bibliothek und den Slot angeben. Nach dem Speichern werden die Werte im Backend übernommen und für neue TLS‑Verbindungen genutzt.
 
 Unter **Settings → Update Interval** legst du fest, in welchem Abstand (in Sekunden) das Zertifikat automatisch aktualisiert wird.
+
+## Minimalbeispiel
+
+1. Worker mit Wrangler erstellen und deployen:
+
+   ```bash
+   bun add -g wrangler
+   wrangler init
+   wrangler secret put SECRET_TOKEN
+   wrangler deploy
+   ```
+
+2. Torwell84 starten und im Einstellungsdialog die URL deines Workers unter
+   **Worker List** eintragen. Den beim Deployment verwendeten Token in das Feld
+   **Worker token** kopieren.
+
+3. Mit **Import Worker List** kannst du eine Datei mit vielen Adressen laden.
+   Über **Export Worker List** lässt sich die aktuelle Konfiguration sichern.
+
+Damit ist der Proxy einsatzbereit. Torwell84 validiert den Token automatisch
+über `validate_worker_token` und verwendet deine Worker anschließend für alle
+Verbindungen.

--- a/scripts/import_workers_cli.ts
+++ b/scripts/import_workers_cli.ts
@@ -1,26 +1,35 @@
 #!/usr/bin/env bun
-import { importWorkersFromFile, parseWorkerList } from './import_workers.ts';
+import { importWorkersFromFile, parseWorkerList } from "./import_workers.ts";
 
 async function main() {
   const file = process.argv[2];
-  const token = process.argv[3] ?? '';
+  const token = process.argv[3] ?? "";
   if (!file) {
-    console.error('Usage: import_workers_cli.ts <file> [token]');
+    console.error("Usage: import_workers_cli.ts <file> [token]");
     process.exit(1);
   }
-  const { readFileSync } = await import('fs');
-  const content = readFileSync(file, 'utf-8');
-  const { invalid, duplicates } = parseWorkerList(content);
-  const result = await importWorkersFromFile(file, token);
-  if (invalid.length > 0) {
-    console.warn(`Ignored ${invalid.length} invalid URLs: ${invalid.join(', ')}`);
-  }
-  if (duplicates.length > 0) {
-    console.warn(
-      `Ignored ${duplicates.length} duplicate entries: ${duplicates.join(', ')}`
+  try {
+    const { readFileSync } = await import("fs");
+    const content = readFileSync(file, "utf-8");
+    const { invalid, duplicates } = parseWorkerList(content);
+    const result = await importWorkersFromFile(file, token);
+    if (invalid.length > 0) {
+      console.warn(
+        `Ignored ${invalid.length} invalid URLs: ${invalid.join(", ")}`,
+      );
+    }
+    if (duplicates.length > 0) {
+      console.warn(
+        `Ignored ${duplicates.length} duplicate entries: ${duplicates.join(", ")}`,
+      );
+    }
+    console.log(`Imported ${result.imported} workers`);
+  } catch (err) {
+    console.error(
+      `Failed to import workers: ${err instanceof Error ? err.message : err}`,
     );
+    process.exit(1);
   }
-  console.log(`Imported ${result.imported} workers`);
 }
 
 main();


### PR DESCRIPTION
## Summary
- handle errors in worker import scripts
- extend http bridge tests for worker configuration validation
- show complete workflow in user docs

## Testing
- `cargo test` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7a062f5483338578513f654b37f4