### PR TITLE
Improve metrics trimming warnings and tests

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -56,6 +56,7 @@ aus, um `bun install` und die Installation von `@sveltejs/kit` automatisch zu st
 
 - Start the app in development mode with `bun tauri dev` to view live output.
 - The backend writes logs to a persistent file named `torwell.log` in the project directory. When the file exceeds the configured line limit it is rotated and the previous log is moved into an `archive` folder.
+- Metrics are stored in `metrics.json`. If the file grows beyond the limits specified via `TORWELL_MAX_METRIC_LINES` or `TORWELL_MAX_METRIC_MB`, it is rotated as well and a warning is shown in the system tray.
 - Each line of this file is a JSON object with `level`, `timestamp` and `message` fields.
 - If the UI fails to load, open the browser developer tools (`Ctrl+Shift+I`) to inspect console logs and network activity.
 - Failed connection attempts are recorded with `WARN` level. The retry counter resets when a new connection starts.


### PR DESCRIPTION
## Summary
- trim_metrics now warns via tray when metrics file exceeds configured size or line limits
- test trimming of large log and metrics files
- test env variable overrides for metric limits
- document size limits in troubleshooting guide

## Testing
- `bun run check` *(fails: `svelte-kit` not found)*
- `cargo test` *(fails: glib-2.0 development headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e9812654c83338483b30c2cfc9b5d