### PR TITLE
Configure production cert endpoint

### DIFF
--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -73,9 +73,11 @@ Copy `docs/examples/cert_config.json` to `src-tauri/certs/cert_config.json` and 
 ```
 
 Set the environment variables so `SecureHttpClient` can locate the
-certificate and HSM library:
+certificate and update endpoint:
 
 ```bash
+export TORWELL_CERT_URL=https://updates.torwell.com/certs/server.pem
+export TORWELL_FALLBACK_CERT_URL=https://backup.torwell.com/server.pem
 export TORWELL_CERT_PATH=/etc/torwell/server.pem
 export TORWELL_HSM_LIB=/usr/local/lib/libyubihsm_pkcs11.so
 ```


### PR DESCRIPTION
## Summary
- keep `cert_config.json` updated with the production server URL
- document environment variables for certificate updates

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace` *(fails: glib-2.0.pc not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f015587348333a4e5c42c3c27c7c2