### PR TITLE
Update prod certificate URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    env:
+      TAURI_UPDATE_URL: https://updates.torwell.com
+      TORWELL_CERT_URL: https://certs.torwell.com/server.pem
+      TORWELL_CERT_PATH: /etc/torwell/server.pem
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -126,6 +130,10 @@ jobs:
   release:
     needs: [build, android, ios]
     runs-on: ubuntu-latest
+    env:
+      TAURI_UPDATE_URL: https://updates.torwell.com
+      TORWELL_CERT_URL: https://certs.torwell.com/server.pem
+      TORWELL_CERT_PATH: /etc/torwell/server.pem
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/docs/ProductionCertificate.md
+++ b/docs/ProductionCertificate.md
@@ -9,7 +9,7 @@ Create a PEM encoded certificate with your internal or public CA. For quick test
 ```bash
 openssl req -new -newkey rsa:4096 -days 90 -nodes -x509 \
     -keyout server.key -out server.pem \
-    -subj "/CN=certs.yourdomain.example"
+    -subj "/CN=certs.torwell.com"
 ```
 
 Place `server.pem` on your update server. Renew the file every 90 days.
@@ -21,7 +21,7 @@ Use the example configuration in `docs/examples/cert_config.json` as a template.
 ```json
 {
   "cert_path": "/etc/torwell/server.pem",
-  "cert_url": "https://updates.example.com/certs/server.pem",
+  "cert_url": "https://certs.torwell.com/server.pem",
   "fallback_cert_url": null,
   "min_tls_version": "1.2"
 }
@@ -29,17 +29,17 @@ Use the example configuration in `docs/examples/cert_config.json` as a template.
 
 ## 3. Set Up Your Update Endpoint
 
-Host `server.pem` on a web server reachable via HTTPS. The path must match the `cert_url` value from the configuration file, e.g. `https://updates.example.com/certs/server.pem`.  Ensure the file is replaced whenever a new certificate is issued.
+Host `server.pem` on a web server reachable via HTTPS. The path must match the `cert_url` value from the configuration file, e.g. `https://certs.torwell.com/server.pem`.  Ensure the file is replaced whenever a new certificate is issued.
 
 A minimal Nginx setup might look like this:
 
 ```nginx
 server {
     listen 443 ssl;
-    server_name updates.example.com;
+    server_name certs.torwell.com;
 
-    ssl_certificate /etc/letsencrypt/live/updates.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/updates.example.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/certs.torwell.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/certs.torwell.com/privkey.pem;
 
     location /certs/ {
         alias /var/www/certs/;
@@ -63,7 +63,7 @@ Automate uploads with a cronjob that calls a small script after each renewal:
 #!/bin/bash
 set -e
 scp /pki/torwell/server.pem \
-    user@updates.example.com:/var/www/certs/server.pem
+    user@certs.torwell.com:/var/www/certs/server.pem
 ```
 
 Running this job ensures that clients can fetch the new certificate during the next update check.
@@ -73,9 +73,9 @@ Running this job ensures that clients can fetch the new certificate during the n
 Instead of editing the configuration file you can override the values at runtime:
 
 ```bash
-export TORWELL_CERT_URL=https://updates.yourdomain.example/certs/server.pem
+export TORWELL_CERT_URL=https://certs.torwell.com/server.pem
 export TORWELL_CERT_PATH=/etc/torwell/server.pem
-export TORWELL_FALLBACK_CERT_URL=https://backup.example.com/server.pem
+export TORWELL_FALLBACK_CERT_URL=https://backup.torwell.com/server.pem
 ```
 
 `SecureHttpClient` prefers environment variables over `cert_config.json` when no parameters are passed to `init`.
@@ -88,7 +88,7 @@ Automate certificate updates with a small script that copies the new PEM to the 
 #!/bin/bash
 set -e
 scp /pki/torwell/server.pem \
-    user@certs.yourdomain.example:/var/www/certs/server.pem
+    user@certs.torwell.com:/var/www/certs/server.pem
 ```
 
 Running this script after each renewal ensures that clients download the new certificate during the next update check.

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -83,7 +83,7 @@ Copy `docs/examples/cert_config.json` to `src-tauri/certs/cert_config.json` and 
 ```json
 {
   "cert_path": "/etc/torwell/server.pem",
-  "cert_url": "https://updates.torwell.com/certs/server.pem",
+  "cert_url": "https://certs.torwell.com/server.pem",
   "fallback_cert_url": null,
   "min_tls_version": "1.2",
   "update_interval": 86400,
@@ -95,7 +95,7 @@ Set the environment variables so `SecureHttpClient` can locate the
 certificate and update endpoint:
 
 ```bash
-export TORWELL_CERT_URL=https://updates.torwell.com/certs/server.pem
+export TORWELL_CERT_URL=https://certs.torwell.com/server.pem
 export TORWELL_FALLBACK_CERT_URL=https://backup.torwell.com/server.pem
 export TORWELL_CERT_PATH=/etc/torwell/server.pem
 export TORWELL_HSM_LIB=/usr/local/lib/libyubihsm_pkcs11.so

--- a/src-tauri/certs/cert_config.json
+++ b/src-tauri/certs/cert_config.json
@@ -2,7 +2,7 @@
   "cert_path": "/etc/torwell/server.pem",
   "cert_path_windows": "%APPDATA%\\Torwell84\\server.pem",
   "cert_path_macos": "/Library/Application Support/Torwell84/server.pem",
-  "cert_url": "https://updates.torwell.com/certs/server.pem",
+  "cert_url": "https://certs.torwell.com/server.pem",
   "fallback_cert_url": null,
   "min_tls_version": "1.2",
   "update_interval": 86400,

--- a/src-tauri/src/secure_http.rs
+++ b/src-tauri/src/secure_http.rs
@@ -27,7 +27,7 @@ use pkcs11::Ctx;
 pub const DEFAULT_CERT_PATH: &str = "src-tauri/certs/server.pem";
 
 /// Default URL for retrieving updated certificates
-pub const DEFAULT_CERT_URL: &str = "https://updates.torwell.com/certs/server.pem";
+pub const DEFAULT_CERT_URL: &str = "https://certs.torwell.com/server.pem";
 
 /// Default location of the certificate configuration file
 pub const DEFAULT_CONFIG_PATH: &str = "src-tauri/certs/cert_config.json";


### PR DESCRIPTION
## Summary
- point cert_config.json and SecureHttpClient to the production server
- document real certificate paths and URLs
- export environment variables in the release workflow

## Testing
- `bun run test` *(fails: 14 failed, 21 passed)*
- `cargo test` *(failed to run due to heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6870b9e0e8b88333aab2414c31eb00fc