### PR TITLE
Improve installation scripts and CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Run cargo audit
         working-directory: src-tauri
         run: cargo audit
+      - name: Test service installer
+        run: ./scripts/test_service_install.sh
 
   frontend:
     runs-on: ubuntu-latest

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -59,6 +59,9 @@ Service file installed in /tmp/tmp.XYZ
 Test completed successfully
 ```
 
+The GitHub Actions workflow executes this script on every pull request to
+validate the service installation logic.
+
 If the application resides in a custom directory or should run under a
 different service account, edit `src-tauri/torwell84.service` before invoking
 the installer. Adjust `ExecStart`, `ExecStartPre`, `WorkingDirectory`, `User`

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -21,6 +21,11 @@ for cmd in bun cargo; do
   check_dep "$cmd"
 done
 
+if [ -z "${TAURI_UPDATE_URL:-}" ]; then
+  echo "Error: TAURI_UPDATE_URL is not set" >&2
+  exit 1
+fi
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Install Node dependencies and build the Tauri project in release mode.

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -33,6 +33,9 @@ fi
 
 # Ensure application directory exists
 $SUDO mkdir -p /opt/torwell84
+if [ ! -f /opt/torwell84/torwell84 ]; then
+  echo "Warning: /opt/torwell84/torwell84 not found" >&2
+fi
 
 # Copy service file to systemd directory
 echo "Copying service file to $TARGET_DIR"


### PR DESCRIPTION
## Summary
- exit build_release.sh when TAURI_UPDATE_URL is missing
- warn in install_service.sh if main binary is absent
- run service installation test in CI
- document CI test in ProductionDeployment guide

## Testing
- `bash scripts/test_service_install.sh | tail -n 8`
- `bash scripts/build_release.sh` *(fails: TAURI_UPDATE_URL is not set)*

------
https://chatgpt.com/codex/tasks/task_e_6870b9e3c4188333b8efca68d11840e6