### PR TITLE
Reduce blur intensity and add aria labels

### DIFF
--- a/src/lib/components/ActionCard.svelte
+++ b/src/lib/components/ActionCard.svelte
@@ -104,7 +104,7 @@
         class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 transition-all duration-300 ease-in-out text-sm bg-yellow-600/20 text-yellow-400 border border-yellow-500/30 opacity-75 cursor-not-allowed"
         disabled={true}
       >
-        <div class="animate-spin"><RefreshCw size={16} /></div>
+        <div class="animate-[spin_2s_linear_infinite]"><RefreshCw size={16} /></div>
         {#if isRetrying}
           Retrying in {$torStore.retryDelay}s (attempt {$torStore.retryCount})
         {:else}
@@ -124,7 +124,7 @@
         class="glass py-3 px-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 transition-all duration-300 ease-in-out text-sm bg-yellow-600/20 text-yellow-400 border border-yellow-500/30 opacity-75 cursor-not-allowed"
         disabled={true}
       >
-        <div class="animate-spin"><RefreshCw size={16} /></div>
+        <div class="animate-[spin_2s_linear_infinite]"><RefreshCw size={16} /></div>
         Disconnecting...
       </button>
     {/if}
@@ -140,7 +140,7 @@
       aria-label="Request new circuit"
     >
       {#if isCreatingCircuit}
-        <div class="animate-spin"><RefreshCw size={16} /></div>
+        <div class="animate-[spin_2s_linear_infinite]"><RefreshCw size={16} /></div>
         Creating...
       {:else}
         <RotateCcw size={16} /> New Circuit

--- a/src/lib/components/CircuitList.svelte
+++ b/src/lib/components/CircuitList.svelte
@@ -34,7 +34,13 @@
     {#each circuits as id}
       <li class="flex items-center justify-between text-xs text-white bg-black/50 rounded px-2 py-1">
         <span>#{id}</span>
-        <button class="text-red-200 hover:text-red-400" on:click={() => close(id)}>Close</button>
+        <button
+          class="text-red-200 hover:text-red-400"
+          on:click={() => close(id)}
+          aria-label="Close circuit"
+        >
+          Close
+        </button>
       </li>
     {/each}
     {#if circuits.length === 0}

--- a/src/lib/components/CircuitManager.svelte
+++ b/src/lib/components/CircuitManager.svelte
@@ -31,7 +31,13 @@
     {#each circuits as id}
       <li class="flex items-center justify-between text-xs text-white bg-black/50 rounded px-2 py-1">
         <span>#{id}</span>
-        <button class="text-red-200 hover:text-red-400" on:click={() => close(id)}>Close</button>
+        <button
+          class="text-red-200 hover:text-red-400"
+          on:click={() => close(id)}
+          aria-label="Close circuit"
+        >
+          Close
+        </button>
       </li>
     {/each}
     {#if circuits.length === 0}

--- a/src/lib/components/LogsModal.svelte
+++ b/src/lib/components/LogsModal.svelte
@@ -134,7 +134,7 @@
                on:keydown={trapFocus}
        >
                <div
-                       class="glass-lg rounded-2xl w-full max-w-4xl max-h-[80vh] overflow-hidden"
+                       class="glass-md rounded-2xl w-full max-w-4xl max-h-[80vh] overflow-hidden"
                        role="dialog"
                        aria-modal="true"
                        aria-labelledby="logs-modal-title"
@@ -183,7 +183,7 @@
                         <div class="p-6 max-h-96 overflow-y-auto" role="log" aria-live="polite">
                                 {#if isLoading}
                                         <div class="text-center text-gray-100 py-8">
-						<div class="animate-spin w-6 h-6 border-2 border-blue-400 border-t-transparent rounded-full mx-auto mb-2"></div>
+						<div class="animate-[spin_2s_linear_infinite] w-6 h-6 border-2 border-blue-400 border-t-transparent rounded-full mx-auto mb-2"></div>
 						Loading logs...
 					</div>
                                 {:else if filteredLogs.length === 0}

--- a/src/lib/components/SettingsModal.svelte
+++ b/src/lib/components/SettingsModal.svelte
@@ -182,7 +182,7 @@
     on:keydown={trapFocus}
   >
     <section
-      class="glass-lg rounded-2xl w-[90%] max-w-2xl min-h-[500px] p-6 flex flex-col"
+      class="glass-md rounded-2xl w-[90%] max-w-2xl min-h-[500px] p-6 flex flex-col"
       on:pointerdown|stopPropagation
       bind:this={modalEl}
       role="dialog"

--- a/src/lib/components/StatusCard.svelte
+++ b/src/lib/components/StatusCard.svelte
@@ -150,14 +150,14 @@
           <!-- Animated ripples during ping -->
           <div class="relative w-full h-full flex items-center justify-center">
             <div
-              class="absolute w-2 h-2 bg-blue-400/60 rounded-full animate-ping"
+              class="absolute w-2 h-2 bg-blue-400/60 rounded-full animate-[ping_2s_linear_infinite]"
             ></div>
             <div
-              class="absolute w-3 h-3 bg-blue-400/40 rounded-full animate-ping"
+              class="absolute w-3 h-3 bg-blue-400/40 rounded-full animate-[ping_2s_linear_infinite]"
               style="animation-delay: 0.2s;"
             ></div>
             <div
-              class="absolute w-4 h-4 bg-blue-400/20 rounded-full animate-ping"
+              class="absolute w-4 h-4 bg-blue-400/20 rounded-full animate-[ping_2s_linear_infinite]"
               style="animation-delay: 0.4s;"
             ></div>
             <div class="w-1.5 h-1.5 bg-blue-400 rounded-full"></div>

--- a/src/lib/components/TorrcEditorModal.svelte
+++ b/src/lib/components/TorrcEditorModal.svelte
@@ -62,7 +62,7 @@
     on:keydown={trapFocus}
   >
     <section
-      class="glass-lg rounded-2xl w-[90%] max-w-2xl p-6 flex flex-col"
+      class="glass-md rounded-2xl w-[90%] max-w-2xl p-6 flex flex-col"
       on:pointerdown|stopPropagation
       bind:this={modalEl}
       role="dialog"

--- a/src/lib/components/WorkerSetupModal.svelte
+++ b/src/lib/components/WorkerSetupModal.svelte
@@ -71,7 +71,7 @@
     on:keydown={trapFocus}
   >
     <section
-      class="glass-lg rounded-2xl w-[90%] max-w-2xl p-6 flex flex-col"
+      class="glass-md rounded-2xl w-[90%] max-w-2xl p-6 flex flex-col"
       on:pointerdown|stopPropagation
       bind:this={modalEl}
       role="dialog"
@@ -103,6 +103,7 @@
       <button
         class="text-sm py-2 px-4 mt-4 rounded-xl border-transparent font-medium flex items-center justify-center gap-2 cursor-pointer transition-all w-auto bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
         on:click={() => filePicker && filePicker.click()}
+        aria-label="Import worker list"
       >
         Import Worker List
       </button>


### PR DESCRIPTION
## Summary
- decrease glass blur levels in modal components
- slow down spin/ping animations for better performance
- add aria-labels to circuit and worker setup buttons

## Testing
- `npm test` *(fails: Unable to find accessible element)*
- `cargo test` *(fails: could not update crates)*

------
https://chatgpt.com/codex/tasks/task_e_6870b9e425288333a7e473034b2ca8ce