### PR TITLE
Improve mobile build scripts and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,3 +224,29 @@ jobs:
         with:
           name: macos-dmg
           path: src-tauri/target/release/bundle/dmg/*.dmg
+
+  mobile:
+    needs: [backend, frontend]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: android
+          - os: macos-latest
+            platform: ios
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: task mobile:${{ matrix.platform }}
+      - name: Validate artifact
+        run: ./mobile/scripts/test_artifacts.sh ${{ matrix.platform }}

--- a/docs/Mobile.md
+++ b/docs/Mobile.md
@@ -5,6 +5,15 @@ The Svelte frontend is reused by pointing `webDir` to the compiled web assets.
 
 ## Build Steps
 
+### Supported Platforms
+
+The mobile build targets the following OS versions:
+
+- **Android:** API level 34 (Android 14) or newer
+- **iOS:** iOS 17 or newer
+
+Older versions may work but are not officially tested.
+
 1. Run `task setup` once to install all dependencies.
 2. Use the `Taskfile` targets to build the apps:
 

--- a/mobile/scripts/build_android.sh
+++ b/mobile/scripts/build_android.sh
@@ -8,13 +8,19 @@
 # and that the ANDROID_HOME or ANDROID_SDK_ROOT environment variable is set.
 set -euo pipefail
 
-trap 'echo "[ERROR] Build failed at line $LINENO" >&2' ERR
+# Provide the line number of the failing command to ease troubleshooting
+trap 'echo "[ERROR] Build aborted at line $LINENO. See output above for details." >&2' ERR
 
 check_dep() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "[ERROR] '$1' is required but not installed." >&2
     missing=1
   fi
+}
+
+# Convenience helper for prominent error messages
+error() {
+  echo "[ERROR] $*" >&2
 }
 
 
@@ -31,24 +37,24 @@ for cmd in bun cargo npx java gradle; do
 done
 
 if ! npx cap --version >/dev/null 2>&1; then
-  echo "[ERROR] Capacitor CLI not found. Run 'bun install' first." >&2
+  error "Capacitor CLI not found. Run 'bun install' first."
   missing=1
 fi
 
 if [ -z "${ANDROID_HOME:-}" ] && [ -z "${ANDROID_SDK_ROOT:-}" ] && ! command -v sdkmanager >/dev/null 2>&1; then
-  echo "[ERROR] Android SDK not found. Please set ANDROID_HOME or ANDROID_SDK_ROOT." >&2
+  error "Android SDK not found. Set ANDROID_HOME or ANDROID_SDK_ROOT to the SDK path."
   missing=1
 fi
 
 SDK_PATH="${ANDROID_HOME:-$ANDROID_SDK_ROOT}"
 if [ -n "$SDK_PATH" ] && [ ! -d "$SDK_PATH/platforms/android-$REQUIRED_API" ]; then
-  echo "[ERROR] Android SDK platform $REQUIRED_API not installed in $SDK_PATH" >&2
-  echo "Install with: sdkmanager \"platforms;android-$REQUIRED_API\"" >&2
+  error "Android SDK platform $REQUIRED_API missing in $SDK_PATH"
+  echo "       Install with: sdkmanager \"platforms;android-$REQUIRED_API\"" >&2
   missing=1
 fi
 
 if [ "$missing" -eq 1 ]; then
-  echo "[ERROR] Missing dependencies detected. Aborting." >&2
+  error "Missing dependencies detected. Aborting build."
   exit 1
 fi
 
@@ -75,7 +81,10 @@ npx cap sync android
 msg "Copying assets"
 npx cap copy android
 msg "Building Android project"
-npx cap build android
+if ! npx cap build android; then
+  error "Capacitor build failed. Ensure the Android SDK and Gradle are correctly installed."
+  exit 1
+fi
 
 APK_PATH=$(find android/app/build/outputs/apk -name '*.apk' | head -n 1 || true)
 if [ -n "$APK_PATH" ] && [ -f "$APK_PATH" ]; then
@@ -84,6 +93,6 @@ if [ -n "$APK_PATH" ] && [ -f "$APK_PATH" ]; then
   cp "$APK_PATH" "$DEST_DIR/"
   msg "APK copied to $DEST_DIR/$(basename "$APK_PATH")"
 else
-  echo "[ERROR] No APK produced" >&2
+  error "No APK produced. Check the build log for details."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- expand logging in `build_android.sh` and `build_ios.sh`
- validate APK/IPA in CI via new job
- document supported mobile platforms

## Testing
- `bun run test` *(fails: vitest not found)*
- `bunx svelte-check` *(fails: command not found)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6870b9e54d108333a37a403551bbdbf4