### PR TITLE
Update certificate URL

### DIFF
--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -41,7 +41,7 @@ locations during development.
   "cert_path": "/etc/torwell/server.pem",
   "cert_path_windows": "%APPDATA%\\Torwell84\\server.pem",
   "cert_path_macos": "/Library/Application Support/Torwell84/server.pem",
-  "cert_url": "https://certs.torwell.com/server.pem",
+  "cert_url": "https://updates.yourdomain.example/certs/server.pem",
   "fallback_cert_url": null,
   "min_tls_version": "1.2",
   "update_interval": 86400
@@ -91,7 +91,7 @@ let client = SecureHttpClient::init(
 
 ## Konfiguration
 
-Der Standardwert für `cert_url` verweist auf `https://certs.torwell.com/server.pem` und dient lediglich als Platzhalter.
+Der Standardwert für `cert_url` verweist auf `https://updates.yourdomain.example/certs/server.pem` und dient lediglich als Platzhalter.
 Für produktive Einsätze muss dieser Wert auf den eigenen Update-Server zeigen.
 Dazu öffnen Sie `src-tauri/certs/cert_config.json` und ersetzen die URL durch den gewünschten Endpunkt.
 Alternativ können Sie beim Aufruf von `SecureHttpClient::init` einen abweichenden Wert übergeben, ohne die Datei zu verändern.
@@ -147,7 +147,7 @@ Das Skript `push_cert.sh` könnte beispielsweise so aussehen:
 #!/bin/bash
 set -e
 scp /pki/torwell/server.pem \
-    user@certs.torwell.com:/var/www/certs/server.pem
+    user@updates.yourdomain.example:/var/www/certs/server.pem
 ```
 
 Nach der Übertragung steht das neue Zertifikat umgehend für alle Clients zum
@@ -164,7 +164,7 @@ Neustart der Anwendung erforderlich ist.
 ### Rotation Workflow
 
 1. Lege das neue Zertifikat auf dem Produktionsserver unter
-   `https://certs.torwell.com/server.pem` ab.
+   `https://updates.yourdomain.example/certs/server.pem` ab.
 2. Beim Start liest `SecureHttpClient` `cert_config.json` ein und
    verwendet `cert_url`, sofern keine Umgebungsvariable gesetzt ist.
    Wird `TORWELL_CERT_URL` definiert, hat dieser Wert Vorrang.
@@ -190,7 +190,7 @@ sicherstellt, dass immer ein gültiges Zertifikat vorliegt.
 
 1. **Quellserver**
    Das frische Zertifikat wird von der unternehmensinternen PKI erzeugt und auf
-   dem Update-Server unter `https://certs.torwell.com/server.pem` abgelegt. Der
+   dem Update-Server unter `https://updates.yourdomain.example/certs/server.pem` abgelegt. Der
    Pfad ist in `cert_config.json` hinterlegt und kann über
    `TORWELL_CERT_URL` überschrieben werden.
 2. **Zeitplan**

--- a/docs/ProductionCertificate.md
+++ b/docs/ProductionCertificate.md
@@ -9,7 +9,7 @@ Create a PEM encoded certificate with your internal or public CA. For quick test
 ```bash
 openssl req -new -newkey rsa:4096 -days 90 -nodes -x509 \
     -keyout server.key -out server.pem \
-    -subj "/CN=certs.torwell.com"
+    -subj "/CN=updates.yourdomain.example"
 ```
 
 Place `server.pem` on your update server. Renew the file every 90 days.
@@ -21,7 +21,7 @@ Use the example configuration in `docs/examples/cert_config.json` as a template.
 ```json
 {
   "cert_path": "/etc/torwell/server.pem",
-  "cert_url": "https://certs.torwell.com/server.pem",
+  "cert_url": "https://updates.yourdomain.example/certs/server.pem",
   "fallback_cert_url": null,
   "min_tls_version": "1.2"
 }
@@ -29,17 +29,17 @@ Use the example configuration in `docs/examples/cert_config.json` as a template.
 
 ## 3. Set Up Your Update Endpoint
 
-Host `server.pem` on a web server reachable via HTTPS. The path must match the `cert_url` value from the configuration file, e.g. `https://certs.torwell.com/server.pem`.  Ensure the file is replaced whenever a new certificate is issued.
+Host `server.pem` on a web server reachable via HTTPS. The path must match the `cert_url` value from the configuration file, e.g. `https://updates.yourdomain.example/certs/server.pem`.  Ensure the file is replaced whenever a new certificate is issued.
 
 A minimal Nginx setup might look like this:
 
 ```nginx
 server {
     listen 443 ssl;
-    server_name certs.torwell.com;
+    server_name updates.yourdomain.example;
 
-    ssl_certificate /etc/letsencrypt/live/certs.torwell.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/certs.torwell.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/updates.yourdomain.example/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/updates.yourdomain.example/privkey.pem;
 
     location /certs/ {
         alias /var/www/certs/;
@@ -63,7 +63,7 @@ Automate uploads with a cronjob that calls a small script after each renewal:
 #!/bin/bash
 set -e
 scp /pki/torwell/server.pem \
-    user@certs.torwell.com:/var/www/certs/server.pem
+    user@updates.yourdomain.example:/var/www/certs/server.pem
 ```
 
 Running this job ensures that clients can fetch the new certificate during the next update check.
@@ -73,7 +73,7 @@ Running this job ensures that clients can fetch the new certificate during the n
 Instead of editing the configuration file you can override the values at runtime:
 
 ```bash
-export TORWELL_CERT_URL=https://certs.torwell.com/server.pem
+export TORWELL_CERT_URL=https://updates.yourdomain.example/certs/server.pem
 export TORWELL_CERT_PATH=/etc/torwell/server.pem
 export TORWELL_FALLBACK_CERT_URL=https://backup.torwell.com/server.pem
 ```
@@ -88,7 +88,7 @@ Automate certificate updates with a small script that copies the new PEM to the 
 #!/bin/bash
 set -e
 scp /pki/torwell/server.pem \
-    user@certs.torwell.com:/var/www/certs/server.pem
+    user@updates.yourdomain.example:/var/www/certs/server.pem
 ```
 
 Running this script after each renewal ensures that clients download the new certificate during the next update check.

--- a/src-tauri/certs/cert_config.json
+++ b/src-tauri/certs/cert_config.json
@@ -2,7 +2,7 @@
   "cert_path": "/etc/torwell/server.pem",
   "cert_path_windows": "%APPDATA%\\Torwell84\\server.pem",
   "cert_path_macos": "/Library/Application Support/Torwell84/server.pem",
-  "cert_url": "https://certs.torwell.com/server.pem",
+  "cert_url": "https://updates.yourdomain.example/certs/server.pem",
   "fallback_cert_url": null,
   "min_tls_version": "1.2",
   "update_interval": 86400,


### PR DESCRIPTION
## Summary
- use new URL in `cert_config.json`
- document the new update domain in production cert guide
- mention new URL in certificate management docs

## Testing
- `npm test` *(fails: vitest not found)*
- `cargo build` *(fails: glib-2.0 development headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871016f5cec8333a2c73bdee575f77e