### PR TITLE
Mention TORWELL_UPDATE_INTERVAL

### DIFF
--- a/docs/CertificateManagement.md
+++ b/docs/CertificateManagement.md
@@ -227,8 +227,10 @@ und Probleme frühzeitig erkannt werden.
 Beim Start liest `SecureHttpClient` das Feld `update_interval` aus
 `cert_config.json`. Ist der Wert größer als 0, startet eine Hintergrundaufgabe,
 die in diesem Abstand `update_certificates_from` aufruft. Ein Wert von `0`
-deaktiviert die automatische Aktualisierung. Das Intervall kann alternativ über
-die Umgebungsvariable `TORWELL_UPDATE_INTERVAL` angepasst werden, z. B.:
+deaktiviert die automatische Aktualisierung. Alternativ kann das Intervall 
+über die Umgebungsvariable `TORWELL_UPDATE_INTERVAL` angepasst werden. 
+Setzen Sie `TORWELL_UPDATE_INTERVAL=0`, um den Dienst auszuschalten, 
+oder wählen Sie einen anderen Sekundenwert, z. B.:
 
 ```bash
 export TORWELL_UPDATE_INTERVAL=86400

--- a/docs/ProductionDeployment.md
+++ b/docs/ProductionDeployment.md
@@ -116,7 +116,7 @@ export TORWELL_HSM_LIB=/usr/local/lib/libyubihsm_pkcs11.so
 The application reads `update_interval` from the configuration file at startup.
 If the value is greater than zero, a background task periodically calls
 `update_certificates_from` to refresh the pinned certificate. You can override
-the interval at runtime using the `TORWELL_UPDATE_INTERVAL` environment variable. Set it to `0` to disable the update service entirely or use a custom number of seconds for testing:
+the interval at runtime using the `TORWELL_UPDATE_INTERVAL` environment variable. Set `TORWELL_UPDATE_INTERVAL=0` to disable the update service entirely or use a custom number of seconds for testing:
 
 ```bash
 export TORWELL_UPDATE_INTERVAL=86400


### PR DESCRIPTION
## Summary
- mention the TORWELL_UPDATE_INTERVAL env var in ProductionDeployment
- note the same variable in CertificateManagement

## Testing
- `cargo check` *(fails: glib-2.0.pc missing)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*
- `bun run check` *(fails: svelte-kit not found)*
- `bun run lint:a11y` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710b00bcf083339e66421f665901ad