### PR TITLE
refactor: route and components use API invoke wrapper

### DIFF
--- a/src/lib/components/NetworkMonitor.svelte
+++ b/src/lib/components/NetworkMonitor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { listen } from '@tauri-apps/api/event';
-  import { invoke } from '@tauri-apps/api/tauri';
+  import { invoke } from '$lib/api';
   import type { MetricPoint } from '$lib/stores/torStore';
   export let className = '';
 
@@ -47,7 +47,7 @@
     let unlisten: (() => void) | undefined;
     (async () => {
       try {
-        const data = await invoke<MetricPoint[]>('load_metrics');
+        const data = (await invoke('load_metrics')) as MetricPoint[];
         metrics = data.slice(-MAX_POINTS);
       } catch (e) {
         console.error('Failed to load metrics', e);

--- a/src/lib/components/ResourceDashboard.svelte
+++ b/src/lib/components/ResourceDashboard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { listen } from '@tauri-apps/api/event';
-  import { invoke } from '@tauri-apps/api/tauri';
+  import { invoke } from '$lib/api';
   import MetricsChart from './MetricsChart.svelte';
   import type { MetricPoint } from '$lib/stores/torStore';
 
@@ -53,7 +53,7 @@
     let unlisten: (() => void) | undefined;
     (async () => {
       try {
-        const data = await invoke<MetricPoint[]>('load_metrics');
+        const data = (await invoke('load_metrics')) as MetricPoint[];
         metrics = data.map((m) => ({ ...m, complete: true })).slice(-MAX_POINTS);
       } catch (e) {
         console.error('Failed to load metrics', e);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
   let SettingsModalComponent: any = null;
   import { uiStore } from "$lib/stores/uiStore";
   import { torStore } from "$lib/stores/torStore";
-  import { invoke } from "@tauri-apps/api/tauri";
+  import { invoke } from "$lib/api";
 
   import { onMount } from "svelte";
 
@@ -24,7 +24,7 @@
   async function fetchCircuit() {
     if ($torStore.status === "CONNECTED") {
       try {
-        activeCircuit = await invoke("get_active_circuit");
+        activeCircuit = (await invoke("get_active_circuit")) as any[];
       } catch (e) {
         console.error("Failed to get active circuit:", e);
         activeCircuit = [];
@@ -37,7 +37,7 @@
   async function fetchIsolatedCircuit() {
     if ($torStore.status === "CONNECTED") {
       try {
-        const nodes = await invoke<any>("get_isolated_circuit", { domain: isolatedDomain });
+        const nodes = (await invoke("get_isolated_circuit", { domain: isolatedDomain })) as any;
         isolatedCircuits = [{ domain: isolatedDomain, nodes }];
       } catch (e) {
         console.error("Failed to get isolated circuit:", e);
@@ -51,7 +51,7 @@
   async function fetchTraffic() {
     if ($torStore.status === "CONNECTED") {
       try {
-        const stats = await invoke<any>("get_traffic_stats");
+        const stats = (await invoke("get_traffic_stats")) as any;
         const bytes = stats.bytes_sent + stats.bytes_received;
         totalTrafficMB = Math.round(bytes / 1_000_000);
       } catch (e) {


### PR DESCRIPTION
## Summary
- Replace direct `@tauri-apps/api` invocations in page and components with `$lib/api` wrapper
- Ensure wrapper adds session token and retries token errors

## Testing
- `npm run check`
- `npm test` *(fails: NotFoundError and multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f6c67fc88333b5a6a6dae2431024